### PR TITLE
[feat/#1] 웹소캣을 적용한 채팅 API 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,6 +62,9 @@ dependencies {
 
     // 모킹 테스트
     testImplementation("io.mockk:mockk:1.14.5")
+
+    // 웹소켓
+    implementation("org.springframework.boot:spring-boot-starter-websocket")
 }
 
 kotlin {

--- a/src/main/kotlin/goodspace/teaming/chat/controller/ChatController.kt
+++ b/src/main/kotlin/goodspace/teaming/chat/controller/ChatController.kt
@@ -1,0 +1,68 @@
+package goodspace.teaming.chat.controller
+
+import goodspace.teaming.chat.dto.ChatMessageResponseDto
+import goodspace.teaming.chat.dto.ChatSendRequestDto
+import goodspace.teaming.chat.service.ChatService
+import goodspace.teaming.global.security.getUserId
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.messaging.handler.annotation.DestinationVariable
+import org.springframework.messaging.handler.annotation.MessageExceptionHandler
+import org.springframework.messaging.handler.annotation.MessageMapping
+import org.springframework.messaging.handler.annotation.Payload
+import org.springframework.messaging.simp.SimpMessagingTemplate
+import org.springframework.messaging.simp.annotation.SubscribeMapping
+import org.springframework.stereotype.Controller
+import java.security.Principal
+
+private const val PREFIX = "rooms"
+
+@Controller
+@MessageMapping(PREFIX)
+@Tag(
+    name = "채팅 API",
+    description = "AsyncAPI 문서 링크 첨부 예정"
+)
+class ChatController(
+    private val chatService: ChatService,
+    private val messaging: SimpMessagingTemplate
+) {
+    @MessageMapping("/{roomId}/send")
+    fun sendMessage(
+        @DestinationVariable roomId: Long,
+        @Payload requestDto: ChatSendRequestDto,
+        principal: Principal
+    ) {
+        val senderId = principal.getUserId()
+
+        val savedMessage = chatService.saveMessage(senderId, roomId, requestDto)
+
+        messaging.convertAndSend("/topic/$PREFIX/$roomId", savedMessage)
+    }
+
+    @SubscribeMapping("/{roomId}/initial")
+    fun initialHistory(
+        @DestinationVariable roomId: Long,
+        principal: Principal
+    ): List<ChatMessageResponseDto> {
+        val userId = principal.getUserId()
+
+        return chatService.findRecentMessages(userId, roomId)
+    }
+
+    /**
+     * 예외 발생시 개인 큐로 전송
+     */
+    @MessageExceptionHandler
+    fun handleException(
+        exception: Exception,
+        principal: Principal?
+    ) {
+        val user = principal?.name ?: return
+
+        messaging.convertAndSendToUser(
+            user,
+            "/queue/errors",
+            exception.message ?: "Unknown Error"
+        )
+    }
+}

--- a/src/main/kotlin/goodspace/teaming/chat/domain/mapper/AttachmentMapper.kt
+++ b/src/main/kotlin/goodspace/teaming/chat/domain/mapper/AttachmentMapper.kt
@@ -1,0 +1,44 @@
+package goodspace.teaming.chat.domain.mapper
+
+import goodspace.teaming.chat.dto.MessageAttachmentDto
+import goodspace.teaming.global.entity.file.AntiVirusScanStatus
+import goodspace.teaming.global.entity.file.Attachment
+import goodspace.teaming.global.entity.file.FileType
+import goodspace.teaming.global.entity.file.TranscodeStatus
+import goodspace.teaming.global.storage.StorageUrlProvider
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+
+@Component
+class AttachmentMapper(
+    private val urlProvider: StorageUrlProvider,
+    @Value("\${mapper.attachment.thumbnail-size:256}")
+    private val thumbnailSize: Int = 256
+) {
+    fun map(attachment: Attachment): MessageAttachmentDto {
+        val file = attachment.file
+        val avPassed = file.antiVirusScanStatus == AntiVirusScanStatus.PASSED
+        val transcodeOk = when (file.type) {
+            FileType.VIDEO, FileType.AUDIO -> file.transcodeStatus == TranscodeStatus.COMPLETED
+            else -> true
+        }
+
+        return MessageAttachmentDto(
+            fileId = requireNotNull(file.id),
+            sortOrder = attachment.sortOrder,
+            name = file.name,
+            type = file.type,
+            mimeType = file.mimeType,
+            byteSize = file.byteSize,
+            width = file.width, height = file.height, durationMs = file.durationMs,
+            previewUrl = urlProvider.publicUrl(file.storageKey),
+            thumbnailUrl = file.thumbnailKey?.let { key ->
+                urlProvider.publicUrl(key = key, size = thumbnailSize)
+            },
+            downloadUrl = urlProvider.downloadUrl(key = file.storageKey, filename =  file.name),
+            antiVirusScanStatus = file.antiVirusScanStatus,
+            transcodeStatus = file.transcodeStatus,
+            ready = avPassed && transcodeOk
+        )
+    }
+}

--- a/src/main/kotlin/goodspace/teaming/chat/domain/mapper/ChatMessageResponseMapper.kt
+++ b/src/main/kotlin/goodspace/teaming/chat/domain/mapper/ChatMessageResponseMapper.kt
@@ -1,0 +1,26 @@
+package goodspace.teaming.chat.domain.mapper
+
+import goodspace.teaming.chat.dto.ChatMessageResponseDto
+import goodspace.teaming.global.entity.room.Message
+import org.springframework.stereotype.Component
+
+@Component
+class ChatMessageResponseMapper(
+    private val attachmentMapper: AttachmentMapper,
+    private val senderSummaryMapper: SenderSummaryMapper
+) {
+    fun map(message: Message): ChatMessageResponseDto {
+        return ChatMessageResponseDto(
+            messageId = message.id!!,
+            roomId = message.room.id!!,
+            clientMessageId = message.clientMessageId,
+            type = message.type,
+            content = message.content,
+            createdAt = message.createdAt!!,
+            sender = senderSummaryMapper.map(message.sender),
+            attachments = message.attachments.map { attachment ->
+                attachmentMapper.map(attachment)
+            }
+        )
+    }
+}

--- a/src/main/kotlin/goodspace/teaming/chat/domain/mapper/SenderSummaryMapper.kt
+++ b/src/main/kotlin/goodspace/teaming/chat/domain/mapper/SenderSummaryMapper.kt
@@ -1,0 +1,23 @@
+package goodspace.teaming.chat.domain.mapper
+
+import goodspace.teaming.chat.dto.SenderSummaryDto
+import goodspace.teaming.global.entity.user.User
+import goodspace.teaming.global.storage.StorageUrlProvider
+import org.springframework.stereotype.Component
+
+@Component
+class SenderSummaryMapper(
+    private val urlProvider: StorageUrlProvider
+) {
+    fun map(user: User, size: Int = 64): SenderSummaryDto {
+        return SenderSummaryDto(
+            id = user.id,
+            name = user.name,
+            avatarUrl = urlProvider.publicUrl(
+                key = user.avatarKey,
+                version = user.avatarVersion,
+                size = size
+            )
+        )
+    }
+}

--- a/src/main/kotlin/goodspace/teaming/chat/dto/ChatMessageResponseDto.kt
+++ b/src/main/kotlin/goodspace/teaming/chat/dto/ChatMessageResponseDto.kt
@@ -1,0 +1,15 @@
+package goodspace.teaming.chat.dto
+
+import goodspace.teaming.global.entity.room.MessageType
+import java.time.LocalDateTime
+
+data class ChatMessageResponseDto(
+    val messageId: Long,
+    val roomId: Long,
+    val clientMessageId: String,
+    val type: MessageType,
+    val content: String?,
+    val createdAt: LocalDateTime,
+    val sender: SenderSummaryDto,
+    val attachments: List<MessageAttachmentDto> = emptyList()
+)

--- a/src/main/kotlin/goodspace/teaming/chat/dto/ChatSendRequestDto.kt
+++ b/src/main/kotlin/goodspace/teaming/chat/dto/ChatSendRequestDto.kt
@@ -1,0 +1,10 @@
+package goodspace.teaming.chat.dto
+
+import goodspace.teaming.global.entity.room.MessageType
+
+data class ChatSendRequestDto(
+    val clientMessageId: String,
+    val content: String? = null,
+    val type: MessageType = MessageType.TEXT,
+    val attachmentFileIdsInOrder: List<Long> = emptyList()
+)

--- a/src/main/kotlin/goodspace/teaming/chat/dto/MessageAttachmentDto.kt
+++ b/src/main/kotlin/goodspace/teaming/chat/dto/MessageAttachmentDto.kt
@@ -1,0 +1,23 @@
+package goodspace.teaming.chat.dto
+
+import goodspace.teaming.global.entity.file.AntiVirusScanStatus
+import goodspace.teaming.global.entity.file.FileType
+import goodspace.teaming.global.entity.file.TranscodeStatus
+
+data class MessageAttachmentDto(
+    val fileId: Long,
+    val sortOrder: Int,
+    val name: String,
+    val type: FileType,
+    val mimeType: String,
+    val byteSize: Long,
+    val width: Int? = null,
+    val height: Int? = null,
+    val durationMs: Int? = null,
+    val previewUrl: String? = null,
+    val thumbnailUrl: String? = null,
+    val downloadUrl: String? = null,
+    val antiVirusScanStatus: AntiVirusScanStatus,
+    val transcodeStatus: TranscodeStatus,
+    val ready: Boolean
+)

--- a/src/main/kotlin/goodspace/teaming/chat/dto/SenderSummaryDto.kt
+++ b/src/main/kotlin/goodspace/teaming/chat/dto/SenderSummaryDto.kt
@@ -1,0 +1,7 @@
+package goodspace.teaming.chat.dto
+
+data class SenderSummaryDto(
+    val id: Long?,
+    val name: String,
+    val avatarUrl: String? = null
+)

--- a/src/main/kotlin/goodspace/teaming/chat/service/ChatService.kt
+++ b/src/main/kotlin/goodspace/teaming/chat/service/ChatService.kt
@@ -1,0 +1,18 @@
+package goodspace.teaming.chat.service
+
+import goodspace.teaming.chat.dto.ChatMessageResponseDto
+import goodspace.teaming.chat.dto.ChatSendRequestDto
+
+interface ChatService {
+    fun saveMessage(
+        userId: Long,
+        roomId: Long,
+        requestDto: ChatSendRequestDto
+    ): ChatMessageResponseDto
+
+    fun findRecentMessages(
+        userId: Long,
+        roomId: Long,
+        amount: Int = 50
+    ): List<ChatMessageResponseDto>
+}

--- a/src/main/kotlin/goodspace/teaming/chat/service/ChatServiceImpl.kt
+++ b/src/main/kotlin/goodspace/teaming/chat/service/ChatServiceImpl.kt
@@ -1,0 +1,120 @@
+package goodspace.teaming.chat.service
+
+import goodspace.teaming.chat.domain.mapper.ChatMessageResponseMapper
+import goodspace.teaming.chat.dto.ChatMessageResponseDto
+import goodspace.teaming.chat.dto.ChatSendRequestDto
+import goodspace.teaming.global.entity.file.AntiVirusScanStatus
+import goodspace.teaming.global.entity.file.Attachment
+import goodspace.teaming.global.entity.file.File
+import goodspace.teaming.global.entity.file.FileType
+import goodspace.teaming.global.entity.room.Message
+import goodspace.teaming.global.entity.room.MessageType
+import goodspace.teaming.global.entity.room.Room
+import goodspace.teaming.global.entity.user.User
+import goodspace.teaming.global.repository.FileRepository
+import goodspace.teaming.global.repository.MessageRepository
+import goodspace.teaming.global.repository.UserRoomRepository
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.dao.DataIntegrityViolationException
+import org.springframework.data.domain.PageRequest
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+private const val ROOM_NOT_FOUND = "티밍룸을 조회할 수 없습니다."
+private const val NOT_EXIST_FILE = "존재하지 않는 파일이 포함되어 있습니다."
+
+@Service
+class ChatServiceImpl(
+    private val userRoomRepository: UserRoomRepository,
+    private val messageRepository: MessageRepository,
+    private val fileRepository: FileRepository,
+    private val chatMessageResponseMapper: ChatMessageResponseMapper,
+    @Value("\${chat.recent-message.lower-bound:1}")
+    private val recentMessageLowerBound: Int,
+    @Value("\${chat.recent-message.upper-bound:200}")
+    private val recentMessageUpperBound: Int,
+) : ChatService {
+    @Transactional
+    override fun saveMessage(userId: Long, roomId: Long, requestDto: ChatSendRequestDto): ChatMessageResponseDto {
+        val userRoom = userRoomRepository.findByRoomIdAndUserId(roomId, userId)
+            ?: throw IllegalArgumentException(ROOM_NOT_FOUND)
+        val user = userRoom.user
+        val room = userRoom.room
+
+        val message = getExistsOrCreate(user, room, requestDto)
+
+        return chatMessageResponseMapper.map(message)
+    }
+
+    @Transactional(readOnly = true)
+    override fun findRecentMessages(userId: Long, roomId: Long, amount: Int): List<ChatMessageResponseDto> {
+        val userRoom = userRoomRepository.findByRoomIdAndUserId(roomId, userId)
+            ?: throw IllegalArgumentException(ROOM_NOT_FOUND)
+
+        val size = amount.coerceIn(recentMessageLowerBound, recentMessageUpperBound)
+
+        return messageRepository.findByRoomOrderByCreatedAtDesc(userRoom.room, PageRequest.of(0, size))
+            .map { chatMessageResponseMapper.map(it) }
+    }
+
+    private fun getExistsOrCreate(user: User, room: Room, requestDto: ChatSendRequestDto): Message {
+        val existMessage = messageRepository.findByClientMessageIdAndRoomAndSender(requestDto.clientMessageId, room, user)
+        if (existMessage != null) {
+            return existMessage
+        }
+
+        // 동시성 대비 try-catch
+        return try {
+            saveNewMessage(user, room, requestDto)
+        } catch (exception: DataIntegrityViolationException) {
+            messageRepository.findByClientMessageIdAndRoomAndSender(requestDto.clientMessageId, room, user)!!
+        }
+    }
+
+    private fun saveNewMessage(user: User, room: Room, requestDto: ChatSendRequestDto): Message {
+        val fileIds = requestDto.attachmentFileIdsInOrder.distinct()
+        val files = fileRepository.findAllById(fileIds)
+        validateFiles(files, fileIds, room, user)
+
+        val message = Message(
+            sender = user,
+            room = room,
+            content = requestDto.content?.trim(),
+            type = findMessageTypeByFiles(files) ?: requestDto.type,
+            clientMessageId = requestDto.clientMessageId
+        )
+        connectFilesWithMessage(message, files, fileIds)
+
+        return messageRepository.save(message)
+    }
+
+    private fun validateFiles(files: List<File>, fileIds: List<Long>, room: Room, user: User) {
+        require(files.size == fileIds.size) { NOT_EXIST_FILE }
+
+        files.forEach { file ->
+            require(file.room.id == room.id && file.user.id == user.id) { "이 방/사용자의 파일이 아닙니다." }
+            require(file.antiVirusScanStatus != AntiVirusScanStatus.INFECTED) { "악성 파일로 차단된 첨부입니다." }
+        }
+    }
+
+    private fun findMessageTypeByFiles(files: List<File>): MessageType? {
+        return when {
+            files.isEmpty() -> null
+            files.any { it.type == FileType.VIDEO } -> MessageType.VIDEO
+            files.any { it.type == FileType.AUDIO } -> MessageType.AUDIO
+            files.all { it.type == FileType.IMAGE } -> MessageType.IMAGE
+            else -> MessageType.FILE
+        }
+    }
+
+    private fun connectFilesWithMessage(message: Message, files: List<File>, fileIds: List<Long>) {
+        if (fileIds.isNotEmpty()) {
+            val fileMap = files.associateBy { it.id }
+
+            fileIds.forEachIndexed { idx, id ->
+                val file = fileMap[id]!!
+                message.attachments.add(Attachment(message = message, file = file, sortOrder = idx))
+            }
+        }
+    }
+}

--- a/src/main/kotlin/goodspace/teaming/chat/service/RoomAccessAuthorizer.kt
+++ b/src/main/kotlin/goodspace/teaming/chat/service/RoomAccessAuthorizer.kt
@@ -1,0 +1,5 @@
+package goodspace.teaming.chat.service
+
+interface RoomAccessAuthorizer {
+    fun assertMemberOf(roomId: Long, userId: Long)
+}

--- a/src/main/kotlin/goodspace/teaming/chat/service/RoomAccessService.kt
+++ b/src/main/kotlin/goodspace/teaming/chat/service/RoomAccessService.kt
@@ -1,0 +1,13 @@
+package goodspace.teaming.chat.service
+
+import goodspace.teaming.global.repository.UserRoomRepository
+import org.springframework.stereotype.Service
+
+@Service
+class RoomAccessService(
+    private val userRoomRepository: UserRoomRepository
+) : RoomAccessAuthorizer {
+    override fun assertMemberOf(roomId: Long, userId: Long) {
+        require(userRoomRepository.existsByRoomIdAndUserId(roomId, userId)) { "해당 방에 대한 구독 권한이 없습니다." }
+    }
+}

--- a/src/main/kotlin/goodspace/teaming/global/entity/file/AntiVirusScanStatus.kt
+++ b/src/main/kotlin/goodspace/teaming/global/entity/file/AntiVirusScanStatus.kt
@@ -1,5 +1,5 @@
 package goodspace.teaming.global.entity.file
 
 enum class AntiVirusScanStatus {
-    PENDING, CLEAN, INFECTED
+    PENDING, PASSED, FAILED, INFECTED
 }

--- a/src/main/kotlin/goodspace/teaming/global/entity/file/Attachment.kt
+++ b/src/main/kotlin/goodspace/teaming/global/entity/file/Attachment.kt
@@ -2,25 +2,21 @@ package goodspace.teaming.global.entity.file
 
 import goodspace.teaming.global.entity.room.Message
 import goodspace.teaming.global.entity.BaseEntity
-import jakarta.persistence.Column
-import jakarta.persistence.Entity
-import jakarta.persistence.GeneratedValue
+import jakarta.persistence.*
+import jakarta.persistence.FetchType.*
 import jakarta.persistence.GenerationType.IDENTITY
-import jakarta.persistence.Id
-import jakarta.persistence.JoinColumn
-import jakarta.persistence.ManyToOne
 import org.hibernate.annotations.SQLDelete
 import org.hibernate.annotations.SQLRestriction
 
 @Entity
 @SQLDelete(sql = "UPDATE attached_file SET deleted = true, deleted_at = NOW() WHERE id = ?")
 @SQLRestriction("deleted = false")
-class AttachedFile(
-    @ManyToOne
+class Attachment(
+    @ManyToOne(fetch = LAZY)
     @JoinColumn(nullable = false)
     val message: Message,
 
-    @ManyToOne
+    @OneToOne(fetch = LAZY)
     @JoinColumn(nullable = false)
     val file: File,
 

--- a/src/main/kotlin/goodspace/teaming/global/entity/file/TranscodeStatus.kt
+++ b/src/main/kotlin/goodspace/teaming/global/entity/file/TranscodeStatus.kt
@@ -1,5 +1,5 @@
 package goodspace.teaming.global.entity.file
 
 enum class TranscodeStatus {
-    NONE, PENDING, DONE, FAILED
+    NONE, PENDING, COMPLETED, FAILED
 }

--- a/src/main/kotlin/goodspace/teaming/global/entity/room/Message.kt
+++ b/src/main/kotlin/goodspace/teaming/global/entity/room/Message.kt
@@ -1,33 +1,61 @@
 package goodspace.teaming.global.entity.room
 
 import goodspace.teaming.global.entity.BaseEntity
+import goodspace.teaming.global.entity.file.Attachment
 import goodspace.teaming.global.entity.user.User
-import jakarta.persistence.Column
-import jakarta.persistence.Entity
-import jakarta.persistence.GeneratedValue
+import jakarta.persistence.*
+import jakarta.persistence.CascadeType.*
+import jakarta.persistence.FetchType.*
 import jakarta.persistence.GenerationType.IDENTITY
-import jakarta.persistence.Id
-import jakarta.persistence.JoinColumn
-import jakarta.persistence.ManyToOne
 import org.hibernate.annotations.SQLDelete
 import org.hibernate.annotations.SQLRestriction
 
 @Entity
+@Table( // TODO: 소프트 딜리트 마이그레이션 후 수정 필요
+    uniqueConstraints = [
+        UniqueConstraint(
+            name = "uk_chat_msg_room_sender_client",
+            columnNames = ["room_id", "sender_id", "client_message_id"]
+        )
+    ],
+    indexes = [
+        Index(name = "idx_chat_msg_room_created_at", columnList = "room_id, created_at"),
+        Index(name = "idx_chat_msg_sender_created_at", columnList = "sender_id, created_at")
+    ]
+)
 @SQLDelete(sql = "UPDATE message SET deleted = true, deleted_at = NOW() WHERE id = ?")
 @SQLRestriction("deleted = false")
 class Message(
-    @ManyToOne
+    @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "sender_id", nullable = false)
     val sender: User,
 
-    @ManyToOne
+    @ManyToOne(fetch = LAZY)
     @JoinColumn(nullable = false)
     val room: Room,
 
+    @Column(columnDefinition = "TEXT")
+    val content: String?,
+
     @Column(nullable = false)
-    val content: String
+    @Enumerated(EnumType.STRING)
+    val type: MessageType = MessageType.TEXT,
+
+    @Column(nullable = false)
+    val clientMessageId: String
 ) : BaseEntity() {
     @Id
     @GeneratedValue(strategy = IDENTITY)
     val id: Long? = null
+
+    @OneToMany(fetch = LAZY, mappedBy = "message", cascade = [ALL])
+    val attachments: MutableList<Attachment> = mutableListOf()
+
+    @PrePersist
+    @PreUpdate
+    fun validate() {
+        require(!(content.isNullOrBlank() && attachments.isEmpty())) {
+            "본문과 첨부가 모두 비어있습니다."
+        }
+    }
 }

--- a/src/main/kotlin/goodspace/teaming/global/entity/room/MessageType.kt
+++ b/src/main/kotlin/goodspace/teaming/global/entity/room/MessageType.kt
@@ -1,0 +1,5 @@
+package goodspace.teaming.global.entity.room
+
+enum class MessageType {
+    TEXT, IMAGE, FILE, VIDEO, AUDIO, SYSTEM_NOTICE
+}

--- a/src/main/kotlin/goodspace/teaming/global/entity/user/OAuthUser.kt
+++ b/src/main/kotlin/goodspace/teaming/global/entity/user/OAuthUser.kt
@@ -16,11 +16,13 @@ class OAuthUser(
 
     email: String,
     name: String,
-    profilePhoto: ByteArray? = null,
+    avatarKey: String? = null,
+    avatarVersion: Int? = null,
     type: UserType
 ) : User(
     email = email,
     name = name,
-    profilePhoto = profilePhoto,
+    avatarKey = avatarKey,
+    avatarVersion = avatarVersion,
     type = type
 )

--- a/src/main/kotlin/goodspace/teaming/global/entity/user/TeamingUser.kt
+++ b/src/main/kotlin/goodspace/teaming/global/entity/user/TeamingUser.kt
@@ -16,11 +16,12 @@ class TeamingUser(
 
     email: String,
     name: String,
-    profilePhoto: ByteArray? = null,
-    type: UserType
+    avatarKey: String? = null,
+    avatarVersion: Int? = null,
 ) : User(
     email = email,
     name = name,
-    profilePhoto = profilePhoto,
-    type = type
+    avatarKey = avatarKey,
+    avatarVersion = avatarVersion,
+    type = UserType.TEAMING
 )

--- a/src/main/kotlin/goodspace/teaming/global/entity/user/User.kt
+++ b/src/main/kotlin/goodspace/teaming/global/entity/user/User.kt
@@ -13,15 +13,16 @@ import org.hibernate.annotations.SQLRestriction
 @Inheritance(strategy = InheritanceType.JOINED)
 @SQLDelete(sql = "UPDATE `user` SET deleted = true, deleted_at = NOW() WHERE id = ?")
 @SQLRestriction("deleted = false")
-class User(
+abstract class User(
     @Column(nullable = false, unique = true)
     var email: String,
 
     @Column(nullable = false)
     var name: String,
 
-    @Lob
-    var profilePhoto: ByteArray? = null,
+    var avatarKey: String? = null,
+
+    var avatarVersion: Int? = null,
 
     @Enumerated(STRING)
     @Column(nullable = false)

--- a/src/main/kotlin/goodspace/teaming/global/repository/AttachmentRepository.kt
+++ b/src/main/kotlin/goodspace/teaming/global/repository/AttachmentRepository.kt
@@ -1,0 +1,6 @@
+package goodspace.teaming.global.repository
+
+import goodspace.teaming.global.entity.file.Attachment
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface AttachmentRepository : JpaRepository<Attachment, Long>

--- a/src/main/kotlin/goodspace/teaming/global/repository/FileRepository.kt
+++ b/src/main/kotlin/goodspace/teaming/global/repository/FileRepository.kt
@@ -1,0 +1,6 @@
+package goodspace.teaming.global.repository
+
+import goodspace.teaming.global.entity.file.File
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface FileRepository : JpaRepository<File, Long>

--- a/src/main/kotlin/goodspace/teaming/global/repository/MessageRepository.kt
+++ b/src/main/kotlin/goodspace/teaming/global/repository/MessageRepository.kt
@@ -1,0 +1,13 @@
+package goodspace.teaming.global.repository
+
+import goodspace.teaming.global.entity.room.Message
+import goodspace.teaming.global.entity.room.Room
+import goodspace.teaming.global.entity.user.User
+import org.springframework.data.domain.Pageable
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface MessageRepository : JpaRepository<Message, Long> {
+    fun findByClientMessageIdAndRoomAndSender(clientMessageId: String, room: Room, sender: User): Message?
+
+    fun findByRoomOrderByCreatedAtDesc(room: Room, pageable: Pageable): List<Message>
+}

--- a/src/main/kotlin/goodspace/teaming/global/repository/RoomRepository.kt
+++ b/src/main/kotlin/goodspace/teaming/global/repository/RoomRepository.kt
@@ -1,0 +1,6 @@
+package goodspace.teaming.global.repository
+
+import goodspace.teaming.global.entity.room.Room
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface RoomRepository : JpaRepository<Room, Long>

--- a/src/main/kotlin/goodspace/teaming/global/repository/UserRoomRepository.kt
+++ b/src/main/kotlin/goodspace/teaming/global/repository/UserRoomRepository.kt
@@ -1,0 +1,10 @@
+package goodspace.teaming.global.repository
+
+import goodspace.teaming.global.entity.room.UserRoom
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface UserRoomRepository : JpaRepository<UserRoom, Long> {
+    fun findByRoomIdAndUserId(roomId: Long, userId: Long): UserRoom?
+
+    fun existsByRoomIdAndUserId(roomId: Long, userId: Long): Boolean
+}

--- a/src/main/kotlin/goodspace/teaming/global/security/PrincipalParser.kt
+++ b/src/main/kotlin/goodspace/teaming/global/security/PrincipalParser.kt
@@ -1,6 +1,0 @@
-package goodspace.teaming.global.security
-
-import java.security.Principal
-
-fun getUserIdFromPrincipal(principal: Principal): Long =
-    principal.name.toLong()

--- a/src/main/kotlin/goodspace/teaming/global/security/PrincipalUtils.kt
+++ b/src/main/kotlin/goodspace/teaming/global/security/PrincipalUtils.kt
@@ -1,0 +1,6 @@
+package goodspace.teaming.global.security
+
+import java.security.Principal
+
+fun Principal.getUserId(): Long =
+    this.name.toLong()

--- a/src/main/kotlin/goodspace/teaming/global/security/SecurityConfig.kt
+++ b/src/main/kotlin/goodspace/teaming/global/security/SecurityConfig.kt
@@ -30,6 +30,7 @@ class SecurityConfig(
                 auth.requestMatchers("/swagger-ui/**").permitAll() // swagger
                     .requestMatchers("/v3/api-docs/**").permitAll() // SpringDoc
                     .requestMatchers("/email/**").permitAll()
+                    .requestMatchers("/ws/**").permitAll() // 웹소캣 핸드셰이크
                     .anyRequest().authenticated()
             }
             .cors { it.configurationSource(configurationSource()) }

--- a/src/main/kotlin/goodspace/teaming/global/storage/CdnStorageUrlProvider.kt
+++ b/src/main/kotlin/goodspace/teaming/global/storage/CdnStorageUrlProvider.kt
@@ -1,0 +1,42 @@
+package goodspace.teaming.global.storage
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+
+@Component
+class CdnStorageUrlProvider(
+    @Value("\${cdn.base}")
+    private val cdnBase: String,
+    @Value("\${cdn.parameter.version:v")
+    private val versionParameterName: String,
+    @Value("\${cdn.parameter.size:s")
+    private val sizeParameterName: String,
+    @Value("\${cdn.parameter.filename:filename")
+    private val filenameParameterName: String,
+) : StorageUrlProvider {
+    override fun publicUrl(key: String?, version: Int?, size: Int?): String? {
+        if (key.isNullOrBlank()) {
+            return null
+        }
+
+        val params = buildList {
+            version?.let { add("$versionParameterName=$it") }
+            size?.let { add("$sizeParameterName=$it") }
+        }.joinToString("&").let { if (it.isBlank()) "" else "?$it" }
+
+        return "$cdnBase/$key$params"
+    }
+
+    override fun downloadUrl(key: String?, filename: String?, version: Int?): String? {
+        if (key.isNullOrBlank()) {
+            return null
+        }
+
+        val queryString = buildList {
+            version?.let { add("$versionParameterName=$it") }
+            filename?.let { add("$filenameParameterName=" + java.net.URLEncoder.encode(it, java.nio.charset.StandardCharsets.UTF_8)) }
+        }.joinToString("&").let { if (it.isBlank()) "" else "?$it" }
+
+        return "$cdnBase/$key$queryString"
+    }
+}

--- a/src/main/kotlin/goodspace/teaming/global/storage/StorageUrlProvider.kt
+++ b/src/main/kotlin/goodspace/teaming/global/storage/StorageUrlProvider.kt
@@ -1,0 +1,9 @@
+package goodspace.teaming.global.storage
+
+interface StorageUrlProvider {
+    /** 이미지/미리보기 등 브라우저가 바로 볼 리소스용 URL */
+    fun publicUrl(key: String?, version: Int? = null, size: Int? = null): String?
+
+    /** 다운로드/저장용 URL (파일명 파라미터 등 포함) */
+    fun downloadUrl(key: String?, filename: String? = null, version: Int? = null): String?
+}

--- a/src/main/kotlin/goodspace/teaming/global/websocket/JwtStompChannelInterceptor.kt
+++ b/src/main/kotlin/goodspace/teaming/global/websocket/JwtStompChannelInterceptor.kt
@@ -1,0 +1,74 @@
+package goodspace.teaming.global.websocket
+
+import goodspace.teaming.chat.service.RoomAccessAuthorizer
+import goodspace.teaming.global.security.TokenProvider
+import goodspace.teaming.global.security.TokenType
+import goodspace.teaming.global.security.getUserId
+import org.springframework.messaging.Message
+import org.springframework.messaging.MessageChannel
+import org.springframework.messaging.simp.stomp.StompCommand
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor
+import org.springframework.messaging.support.ChannelInterceptor
+import org.springframework.stereotype.Component
+
+private const val ROOM_SUBSCRIBE_PREFIX = "/topic/rooms/"
+
+@Component
+class JwtStompChannelInterceptor(
+    private val tokenProvider: TokenProvider,
+    private val roomAccessAuthorizer: RoomAccessAuthorizer
+) : ChannelInterceptor {
+    override fun preSend(message: Message<*>, channel: MessageChannel): Message<*>? {
+        val accessor = StompHeaderAccessor.wrap(message)
+
+        if (accessor.command == StompCommand.CONNECT) {
+            val token = getTokenFromNativeHeader(accessor, "Authorization")
+            validateToken(token)
+
+            setAuthenticationOnAccessor(accessor, token)
+        }
+
+        if (accessor.command == StompCommand.SUBSCRIBE) {
+            val destination = accessor.destination.orEmpty()
+
+            if (destination.startsWith(ROOM_SUBSCRIBE_PREFIX)) {
+                val roomId = getRoomIdFromDestination(destination)
+
+                val userId = accessor.user?.getUserId()
+                    ?: throw IllegalStateException("인증 정보 없음")
+
+                roomAccessAuthorizer.assertMemberOf(roomId, userId)
+            }
+        }
+
+        return message
+    }
+
+    private fun getTokenFromNativeHeader(
+        accessor: StompHeaderAccessor,
+        headerName: String
+    ): String {
+        val rawToken = accessor.getFirstNativeHeader(headerName).orEmpty()
+
+        return rawToken
+            .removePrefix("Bearer ")
+            .ifEmpty { rawToken.removePrefix("bearer ") }
+            .trim()
+    }
+
+    private fun validateToken(token: String) {
+        require(token.isNotBlank() && tokenProvider.validateToken(token, TokenType.ACCESS)) { "부적절한 토큰입니다." }
+    }
+
+    private fun setAuthenticationOnAccessor(
+        accessor: StompHeaderAccessor,
+        token: String
+    ) {
+        accessor.user = tokenProvider.getAuthentication(token)
+    }
+
+    private fun getRoomIdFromDestination(destination: String): Long {
+        return destination.removePrefix(ROOM_SUBSCRIBE_PREFIX).substringBefore('/').toLongOrNull()
+            ?: throw IllegalArgumentException("잘못된 구독 경로: $destination")
+    }
+}

--- a/src/main/kotlin/goodspace/teaming/global/websocket/StompAuthConfig.kt
+++ b/src/main/kotlin/goodspace/teaming/global/websocket/StompAuthConfig.kt
@@ -1,0 +1,14 @@
+package goodspace.teaming.global.websocket
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.messaging.simp.config.ChannelRegistration
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer
+
+@Configuration
+class StompAuthConfig(
+    private val jwtStompChannelInterceptor: JwtStompChannelInterceptor
+) : WebSocketMessageBrokerConfigurer {
+    override fun configureClientInboundChannel(registration: ChannelRegistration) {
+        registration.interceptors(jwtStompChannelInterceptor)
+    }
+}

--- a/src/main/kotlin/goodspace/teaming/global/websocket/StompConfig.kt
+++ b/src/main/kotlin/goodspace/teaming/global/websocket/StompConfig.kt
@@ -1,0 +1,23 @@
+package goodspace.teaming.global.websocket
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.messaging.simp.config.MessageBrokerRegistry
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer
+
+@Configuration
+@EnableWebSocketMessageBroker
+class StompConfig : WebSocketMessageBrokerConfigurer {
+    override fun configureMessageBroker(registry: MessageBrokerRegistry) {
+        registry.enableSimpleBroker("/topic", "/queue")
+        registry.setApplicationDestinationPrefixes("/app")
+        registry.setUserDestinationPrefix("/user")
+    }
+
+    override fun registerStompEndpoints(registry: StompEndpointRegistry) {
+        registry.addEndpoint("/ws")
+            .setAllowedOriginPatterns("*")
+            .withSockJS()
+    }
+}

--- a/src/test/kotlin/goodspace/teaming/chat/domain/mapper/AttachmentMapperTest.kt
+++ b/src/test/kotlin/goodspace/teaming/chat/domain/mapper/AttachmentMapperTest.kt
@@ -1,0 +1,160 @@
+package goodspace.teaming.chat.domain.mapper
+
+import goodspace.teaming.fixture.FileFixture
+import goodspace.teaming.fixture.RoomFixture
+import goodspace.teaming.fixture.TeamingUserFixture
+import goodspace.teaming.global.entity.file.*
+import goodspace.teaming.global.entity.room.Message
+import goodspace.teaming.global.entity.room.MessageType
+import goodspace.teaming.global.storage.StorageUrlProvider
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.EnumSource
+import org.springframework.test.util.ReflectionTestUtils
+
+private const val DEFAULT_PUBLIC_URL = "u"
+private const val DEFAULT_SORT_ORDER = 0
+private const val DEFAULT_DOWNLOAD_URL = "d"
+private const val DEFAULT_CLIENT_ID = "123123"
+private const val DEFAULT_REFLECTION_ID = 99L
+private const val DEFAULT_STORAGE_KEY = "storageKey"
+private const val DEFAULT_THUMBNAIL_KEY = "thumbnailKey"
+private const val THUMBNAIL_SIZE = 256
+
+class AttachmentMapperTest {
+    private val urlProvider = mockk<StorageUrlProvider>()
+    private val mapper = AttachmentMapper(urlProvider, THUMBNAIL_SIZE)
+
+    @BeforeEach
+    fun mocking() {
+        every { urlProvider.publicUrl(any(), any(), any()) } returns DEFAULT_PUBLIC_URL
+        every { urlProvider.downloadUrl(any(), any(), any()) } returns DEFAULT_DOWNLOAD_URL
+    }
+
+    @Test
+    fun `UrlProvider에게 URL을 제공받는다`() {
+        // given
+        val file = getFileFromFixture(FileFixture.IMAGE)
+            .apply { storageKey = DEFAULT_STORAGE_KEY }
+            .apply { thumbnailKey = DEFAULT_THUMBNAIL_KEY }
+        val attachment = getTestAttachmentOf(file)
+
+        // when
+        mapper.map(attachment)
+
+        // then
+        io.mockk.verify { urlProvider.publicUrl(file.storageKey, null, null) }
+        io.mockk.verify { urlProvider.publicUrl(file.thumbnailKey, null, THUMBNAIL_SIZE) }
+        io.mockk.verify { urlProvider.downloadUrl(file.storageKey, file.name, null) }
+
+        io.mockk.confirmVerified(urlProvider)
+    }
+
+    @Test
+    fun `전달한 정렬 순서를 유지한다`() {
+        // given
+        val file = getFileFromFixture(FileFixture.IMAGE)
+        val attachment = getTestAttachmentOf(file, DEFAULT_SORT_ORDER)
+
+        // when
+        val dto = mapper.map(attachment)
+
+        // then
+        assertThat(dto.sortOrder).isEqualTo(DEFAULT_SORT_ORDER)
+    }
+
+    @Test
+    fun `이미지 파일은 안티바이러스를 통과했다면 ready를 true로 한다`() {
+        // given
+        val file = getFileFromFixture(FileFixture.IMAGE)
+        val attachment = getTestAttachmentOf(file)
+
+        // when
+        val dto = mapper.map(attachment)
+
+        // then
+        assertThat(dto.ready).isTrue()
+    }
+
+    @Test
+    fun `비디오 파일은 안티바이러스를 통과하더라도 트랜스코딩이 완료되지 않았다면 ready를 false로 한다`() {
+        // given
+        val file = getFileFromFixture(FileFixture.VIDEO)
+            .apply { antiVirusScanStatus = AntiVirusScanStatus.PASSED }
+            .apply { transcodeStatus = TranscodeStatus.PENDING }
+        val attachment = getTestAttachmentOf(file)
+
+        // when
+        val dto = mapper.map(attachment)
+
+        // then
+        assertThat(dto.ready).isFalse()
+    }
+
+    @ParameterizedTest
+    @EnumSource(FileType::class)
+    fun `안티 바이러스가 실패했다면 항상 ready를 false로 한다`(fileType: FileType) {
+        // given
+        val file = getFileFromFixture(FileFixture.IMAGE)
+            .apply { type = fileType }
+            .apply { antiVirusScanStatus = AntiVirusScanStatus.FAILED }
+        val attachment = getTestAttachmentOf(file)
+
+        // when
+        val dto = mapper.map(attachment)
+
+        // then
+        assertThat(dto.ready).isFalse()
+    }
+
+    @Test
+    fun `썸네일 키가 없으면 thumbnailUrl 값은 null이 된다`() {
+        // given
+        val file = getFileFromFixture(FileFixture.IMAGE)
+            .apply { thumbnailKey = null }
+        val attachment = getTestAttachmentOf(file)
+
+        // when
+        val dto = mapper.map(attachment)
+
+        // then
+        assertThat(dto.thumbnailUrl).isNull()
+    }
+
+    private fun getFileFromFixture(fixture: FileFixture): File {
+        val room = RoomFixture.DEFAULT.getInstance()
+        val user = TeamingUserFixture.A.getInstance()
+
+        val file = fixture.getInstanceWith(room, user)
+        ReflectionTestUtils.setField(file, "id", DEFAULT_REFLECTION_ID)
+
+        return file
+    }
+
+    private fun getTestAttachmentOf(
+        file: File,
+        sortOrder: Int = 0
+    ): Attachment {
+        val message = Message(
+            sender =  file.user,
+            room =  file.room,
+            content = null,
+            type = MessageType.FILE,
+            clientMessageId = DEFAULT_CLIENT_ID,
+        )
+        ReflectionTestUtils.setField(message, "id", DEFAULT_REFLECTION_ID)
+
+        val attachment = Attachment(
+            message = message,
+            file = file,
+            sortOrder = sortOrder
+        )
+        ReflectionTestUtils.setField(attachment, "id", DEFAULT_REFLECTION_ID)
+
+        return attachment
+    }
+}

--- a/src/test/kotlin/goodspace/teaming/chat/domain/mapper/ChatMessageResponseMapperTest.kt
+++ b/src/test/kotlin/goodspace/teaming/chat/domain/mapper/ChatMessageResponseMapperTest.kt
@@ -1,0 +1,229 @@
+package goodspace.teaming.chat.domain.mapper
+
+import goodspace.teaming.chat.dto.ChatMessageResponseDto
+import goodspace.teaming.chat.dto.MessageAttachmentDto
+import goodspace.teaming.chat.dto.SenderSummaryDto
+import goodspace.teaming.fixture.FileFixture
+import goodspace.teaming.fixture.RoomFixture
+import goodspace.teaming.fixture.TeamingUserFixture
+import goodspace.teaming.global.entity.file.Attachment
+import goodspace.teaming.global.entity.file.File
+import goodspace.teaming.global.entity.room.Message
+import goodspace.teaming.global.entity.room.MessageType
+import goodspace.teaming.global.entity.room.Room
+import goodspace.teaming.global.entity.user.TeamingUser
+import goodspace.teaming.global.entity.user.User
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.test.util.ReflectionTestUtils
+import java.time.LocalDateTime
+
+private const val DEFAULT_MESSAGE_ID = 1001L
+private const val DEFAULT_ROOM_ID = 2002L
+private const val DEFAULT_USER_ID = 3003L
+private const val DEFAULT_CLIENT_MESSAGE_ID = "client-123"
+private const val DEFAULT_CONTENT = "hello world"
+private val DEFAULT_CREATED_AT = LocalDateTime.now()
+
+class ChatMessageResponseMapperTest {
+    private val attachmentMapper = mockk<AttachmentMapper>()
+    private val senderSummaryMapper = mockk<SenderSummaryMapper>()
+    private val mapper = ChatMessageResponseMapper(attachmentMapper, senderSummaryMapper)
+
+    @BeforeEach
+    fun setupMocks() {
+        every { senderSummaryMapper.map(any(), any()) } returns SenderSummaryDto(
+            id = DEFAULT_USER_ID,
+            name = "Sender Name",
+            avatarUrl = "https://cdn/avatar.png"
+        )
+    }
+
+    @Nested
+    @DisplayName("기본 필드 매핑")
+    inner class BasicFieldMapping {
+        @Test
+        fun `메시지의 기본 필드를 그대로 매핑한다`() {
+            // given
+            val room = createRoom()
+            val user = createUser()
+            val message = Message(
+                sender = user,
+                room = room,
+                content = DEFAULT_CONTENT,
+                type = MessageType.TEXT,
+                clientMessageId = DEFAULT_CLIENT_MESSAGE_ID
+            )
+            message.createdAt = DEFAULT_CREATED_AT
+            ReflectionTestUtils.setField(message, "id", DEFAULT_MESSAGE_ID)
+
+            // when
+            val dto: ChatMessageResponseDto = mapper.map(message)
+
+            // then
+            assertThat(dto.messageId).isEqualTo(DEFAULT_MESSAGE_ID)
+            assertThat(dto.roomId).isEqualTo(DEFAULT_ROOM_ID)
+            assertThat(dto.clientMessageId).isEqualTo(DEFAULT_CLIENT_MESSAGE_ID)
+            assertThat(dto.type).isEqualTo(MessageType.TEXT)
+            assertThat(dto.content).isEqualTo(DEFAULT_CONTENT)
+            assertThat(dto.createdAt).isEqualTo(DEFAULT_CREATED_AT)
+        }
+    }
+
+    @Nested
+    @DisplayName("첨부 매핑")
+    inner class AttachmentMapping {
+        @Test
+        fun `첨부가 없으면 빈 리스트를 반환한다`() {
+            // given
+            val room = createRoom()
+            val user = createUser()
+            val message = Message(
+                sender = user,
+                room = room,
+                content = DEFAULT_CONTENT,
+                type = MessageType.TEXT,
+                clientMessageId = DEFAULT_CLIENT_MESSAGE_ID
+            )
+            message.createdAt = DEFAULT_CREATED_AT
+            ReflectionTestUtils.setField(message, "id", DEFAULT_MESSAGE_ID)
+
+            // when
+            val dto = mapper.map(message)
+
+            // then
+            assertThat(dto.attachments).isEmpty()
+        }
+
+        @Test
+        fun `매핑 후에도 첨부 파일의 순서가 유지된다`() {
+            // given
+            val room = createRoom()
+            val user = createUser()
+            val message = Message(
+                sender = user,
+                room = room,
+                content = null,
+                type = MessageType.FILE,
+                clientMessageId = DEFAULT_CLIENT_MESSAGE_ID
+            )
+            message.createdAt = DEFAULT_CREATED_AT
+            ReflectionTestUtils.setField(message, "id", DEFAULT_MESSAGE_ID)
+
+            val firstAttachment = createAttachment(
+                file = FileFixture.IMAGE.getInstanceWith(room, user),
+                message = message,
+                sortOrder = 0
+            )
+            val secondAttachment = createAttachment(
+                file = FileFixture.VIDEO.getInstanceWith(room, user),
+                message = message,
+                sortOrder = 1
+            )
+            message.attachments.add(firstAttachment)
+            message.attachments.add(secondAttachment)
+
+            val firstMapped = createAttachmentDto(
+                fileId = 10L,
+                sortOrder = 0,
+                fixture = FileFixture.IMAGE,
+                room = room,
+                user = user,
+                previewUrl = "p1",
+                thumbnailUrl = "t1",
+                downloadUrl = "d1",
+            )
+            val secondMapped = createAttachmentDto(
+                fileId = 20L,
+                sortOrder = 1,
+                fixture = FileFixture.VIDEO,
+                room = room,
+                user = user,
+                previewUrl = "p2",
+                thumbnailUrl = "t2",
+                downloadUrl = "d2",
+            )
+
+            every { attachmentMapper.map(firstAttachment) } returns firstMapped
+            every { attachmentMapper.map(secondAttachment) } returns secondMapped
+
+            // when
+            val dto = mapper.map(message)
+
+            // then
+            assertThat(dto.attachments).containsExactly(firstMapped, secondMapped)
+        }
+    }
+
+    private fun createRoom(): Room {
+        return RoomFixture.DEFAULT.getInstance().also {
+            ReflectionTestUtils.setField(it, "id", DEFAULT_ROOM_ID)
+        }
+    }
+
+    private fun createUser(): TeamingUser {
+        val user = TeamingUserFixture.A.getInstance().also {
+            ReflectionTestUtils.setField(it, "id", DEFAULT_USER_ID)
+        }
+        return user
+    }
+
+    private fun createAttachment(
+        file: File,
+        message: Message,
+        sortOrder: Int
+    ): Attachment {
+        val fileId = getRandomId()
+        ReflectionTestUtils.setField(file, "id", fileId)
+
+        val attachment = Attachment(
+            message = message,
+            file = file,
+            sortOrder = sortOrder
+        )
+        val attachmentId = getRandomId()
+        ReflectionTestUtils.setField(attachment, "id", attachmentId)
+
+        return attachment
+    }
+
+    private fun createAttachmentDto(
+        fileId: Long,
+        sortOrder: Int,
+        fixture: FileFixture,
+        room: Room,
+        user: User,
+        previewUrl: String,
+        thumbnailUrl: String,
+        downloadUrl: String,
+    ): MessageAttachmentDto {
+        val file = fixture.getInstanceWith(room, user)
+
+        return MessageAttachmentDto(
+            fileId = fileId,
+            sortOrder = sortOrder,
+            name = file.name,
+            type = file.type,
+            mimeType = file.mimeType,
+            byteSize = file.byteSize,
+            width = file.width,
+            height = file.height,
+            durationMs = file.durationMs,
+            previewUrl = previewUrl,
+            thumbnailUrl = thumbnailUrl,
+            downloadUrl = downloadUrl,
+            antiVirusScanStatus = file.antiVirusScanStatus,
+            transcodeStatus = file.transcodeStatus,
+            ready = true
+        )
+    }
+
+    private fun getRandomId(): Long {
+        return (1000..9999).random().toLong()
+    }
+}

--- a/src/test/kotlin/goodspace/teaming/chat/domain/mapper/SenderSummaryMapperTest.kt
+++ b/src/test/kotlin/goodspace/teaming/chat/domain/mapper/SenderSummaryMapperTest.kt
@@ -1,0 +1,139 @@
+package goodspace.teaming.chat.domain.mapper
+
+import goodspace.teaming.fixture.TeamingUserFixture
+import goodspace.teaming.global.entity.user.User
+import goodspace.teaming.global.storage.StorageUrlProvider
+import io.mockk.confirmVerified
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.springframework.test.util.ReflectionTestUtils
+
+private const val DEFAULT_PUBLIC_URL = "https://cdn/avatar.png"
+private const val DEFAULT_USER_ID = 42L
+private const val DEFAULT_USER_NAME = "Teaming User"
+private const val DEFAULT_AVATAR_KEY = "avatars/42.png"
+private const val DEFAULT_AVATAR_VERSION = 7
+private const val DEFAULT_SIZE = 64
+private const val CUSTOM_SIZE = 128
+
+class SenderSummaryMapperTest {
+    private val urlProvider = mockk<StorageUrlProvider>()
+    private val mapper = SenderSummaryMapper(urlProvider)
+
+    @BeforeEach
+    fun setupMocks() {
+        every { urlProvider.publicUrl(any(), any(), any()) } answers {
+            val keyArgument = firstArg<String?>()
+            if (keyArgument.isNullOrBlank()) null else DEFAULT_PUBLIC_URL
+        }
+    }
+
+    @Nested
+    @DisplayName("URL 위임 및 파라미터 전달")
+    inner class UrlDelegation {
+        @Test
+        fun `UrlProvider를 통해 avatarUrl을 담는다`() {
+            // given
+            val user = createUser(
+                id = DEFAULT_USER_ID,
+                name = DEFAULT_USER_NAME,
+                avatarKey = DEFAULT_AVATAR_KEY,
+                avatarVersion = DEFAULT_AVATAR_VERSION
+            )
+
+            // when
+            val result = mapper.map(user, DEFAULT_SIZE)
+
+            // then
+            assertThat(result.id).isEqualTo(DEFAULT_USER_ID)
+            assertThat(result.name).isEqualTo(DEFAULT_USER_NAME)
+            assertThat(result.avatarUrl).isEqualTo(DEFAULT_PUBLIC_URL)
+
+            verify { urlProvider.publicUrl(DEFAULT_AVATAR_KEY, DEFAULT_AVATAR_VERSION, DEFAULT_SIZE) }
+            confirmVerified(urlProvider)
+        }
+
+        @Test
+        fun `크기를 지정하면 지정한 값으로 URL을 요청한다`() {
+            // given
+            val user = createUser(
+                id = DEFAULT_USER_ID,
+                name = DEFAULT_USER_NAME,
+                avatarKey = DEFAULT_AVATAR_KEY,
+                avatarVersion = DEFAULT_AVATAR_VERSION
+            )
+
+            // when
+            val result = mapper.map(user, size = CUSTOM_SIZE)
+
+            // then
+            assertThat(result.avatarUrl).isEqualTo(DEFAULT_PUBLIC_URL)
+            verify { urlProvider.publicUrl(DEFAULT_AVATAR_KEY, DEFAULT_AVATAR_VERSION, CUSTOM_SIZE) }
+            confirmVerified(urlProvider)
+        }
+
+        @Test
+        fun `아바타 버전이 없으면 version에는 null을 전달한다`() {
+            // given
+            val user = createUser(
+                id = DEFAULT_USER_ID,
+                name = DEFAULT_USER_NAME,
+                avatarKey = DEFAULT_AVATAR_KEY,
+                avatarVersion = null
+            )
+
+            // when
+            val result = mapper.map(user)
+
+            // then
+            assertThat(result.avatarUrl).isEqualTo(DEFAULT_PUBLIC_URL)
+            verify { urlProvider.publicUrl(DEFAULT_AVATAR_KEY, null, DEFAULT_SIZE) }
+            confirmVerified(urlProvider)
+        }
+    }
+
+    @Nested
+    @DisplayName("키가 없을 때 동작")
+    inner class NullKeyBehavior {
+
+        @Test
+        fun `아바타 키가 없으면 avatarUrl 값도 null이 된다`() {
+            // given
+            val user = createUser(
+                id = DEFAULT_USER_ID,
+                name = DEFAULT_USER_NAME,
+                avatarKey = null,
+                avatarVersion = null
+            )
+
+            // when
+            val result = mapper.map(user)
+
+            // then
+            assertThat(result.avatarUrl).isNull()
+            verify { urlProvider.publicUrl(null, null, DEFAULT_SIZE) }
+            confirmVerified(urlProvider)
+        }
+    }
+
+    private fun createUser(
+        id: Long,
+        name: String,
+        avatarKey: String?,
+        avatarVersion: Int?
+    ): User {
+        val user = TeamingUserFixture.A.getInstance()
+        user.name = name
+        user.avatarKey = avatarKey
+        user.avatarVersion = avatarVersion
+
+        ReflectionTestUtils.setField(user, "id", id)
+        return user
+    }
+}

--- a/src/test/kotlin/goodspace/teaming/chat/service/ChatServiceTest.kt
+++ b/src/test/kotlin/goodspace/teaming/chat/service/ChatServiceTest.kt
@@ -1,0 +1,177 @@
+package goodspace.teaming.chat.service
+
+import goodspace.teaming.chat.domain.mapper.ChatMessageResponseMapper
+import goodspace.teaming.chat.dto.ChatMessageResponseDto
+import goodspace.teaming.chat.dto.ChatSendRequestDto
+import goodspace.teaming.global.entity.room.*
+import goodspace.teaming.global.entity.user.User
+import goodspace.teaming.global.repository.FileRepository
+import goodspace.teaming.global.repository.MessageRepository
+import goodspace.teaming.global.repository.UserRoomRepository
+import io.mockk.*
+import org.assertj.core.api.Assertions.*
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+import org.springframework.data.domain.PageRequest
+import java.lang.IllegalArgumentException
+import kotlin.math.min
+
+private const val ROOM_ID = 999L
+private const val USER_ID = 99L
+private const val WRONG_ID = 9999L
+private const val RECENT_MESSAGE_LOWER_BOUND = 10
+private const val RECENT_MESSAGE_UPPER_BOUND = 50
+
+class ChatServiceTest {
+    private val userRoomRepository = mockk<UserRoomRepository>()
+    private val messageRepository = mockk<MessageRepository>()
+    private val fileRepository = mockk<FileRepository>()
+    private val chatMessageResponseMapper = mockk<ChatMessageResponseMapper>()
+
+    private val chatService: ChatService = ChatServiceImpl(
+        userRoomRepository = userRoomRepository,
+        messageRepository = messageRepository,
+        fileRepository = fileRepository,
+        chatMessageResponseMapper = chatMessageResponseMapper,
+        recentMessageLowerBound = RECENT_MESSAGE_LOWER_BOUND,
+        recentMessageUpperBound = RECENT_MESSAGE_UPPER_BOUND
+    )
+
+    private var existingMessagesCount: Int = 0
+
+    // 공통 픽스쳐
+    private val user = mockk<User>(relaxed = true) { every { id } returns USER_ID }
+    private val room = mockk<Room>(relaxed = true) { every { id } returns ROOM_ID }
+    private val userRoom = createUserRoom(user, room)
+
+    @BeforeEach
+    fun mocking() {
+        clearMocks(userRoomRepository, messageRepository, fileRepository, chatMessageResponseMapper)
+
+        every { userRoomRepository.findByRoomIdAndUserId(any(), any()) } returns null
+        every { userRoomRepository.findByRoomIdAndUserId(ROOM_ID, USER_ID) } returns userRoom
+
+        every { fileRepository.findAllById(any<Iterable<Long>>()) } returns emptyList()
+
+        every { messageRepository.findByClientMessageIdAndRoomAndSender(any(), any(), any()) } returns null
+        every { messageRepository.save(any<Message>()) } answers { firstArg() }
+
+        // 최근 메시지 조회: 페이지 사이즈와 existingMessagesCount에 따라 List<Message> 생성
+        every { messageRepository.findByRoomOrderByCreatedAtDesc(any(), any<PageRequest>()) } answers {
+            val pageRequest = secondArg<PageRequest>()
+            val size = min(pageRequest.pageSize, existingMessagesCount)
+            List(size) { mockk<Message>(relaxed = true) }
+        }
+
+        every { chatMessageResponseMapper.map(any<Message>()) } returns mockk<ChatMessageResponseDto>(relaxed = true)
+
+        existingMessagesCount = 30
+    }
+
+    @Nested
+    @DisplayName("saveMessage")
+    inner class SaveMessage {
+        @Test
+        fun `메시지를 저장한다`() {
+            // given
+            val request = getChatSendRequestDto()
+
+            // when
+            chatService.saveMessage(USER_ID, ROOM_ID, request)
+
+            // then
+            verify(exactly = 1) { messageRepository.save(any<Message>()) }
+        }
+
+        @Test
+        fun `회원이 해당 방에 소속되어 있지 않다면 예외가 발생한다`() {
+            // given
+            val request = getChatSendRequestDto()
+
+            // when & then
+            assertThatThrownBy { chatService.saveMessage(USER_ID, WRONG_ID, request) }
+                .isInstanceOf(IllegalArgumentException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("findRecentMessages")
+    inner class FindRecentMessages {
+        @ParameterizedTest
+        @ValueSource(ints = [20, 30, 40])
+        fun `amount만큼 최신 메시지를 조회한다`(requestAmount: Int) {
+            // given
+            existingMessagesCount = calculateEnoughMessagesCountBy(requestAmount)
+
+            // when
+            val result = chatService.findRecentMessages(USER_ID, ROOM_ID, requestAmount)
+
+            // then
+            assertThat(result.size).isEqualTo(requestAmount)
+        }
+
+        @Test
+        fun `기존에 존재하는 메시지가 limit보다 작다면, 있는 만큼만 반환한다`() {
+            // given
+            existingMessagesCount = 7
+            val requestAmount = 40
+
+            // when
+            val result = chatService.findRecentMessages(USER_ID, ROOM_ID, requestAmount)
+
+            // then
+            assertThat(result.size).isEqualTo(existingMessagesCount)
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = [1000, 2000, 3000])
+        fun `너무 많은 양의 메시지를 요청하면, 상한선까지만 제공한다`(requestAmount: Int) {
+            // given
+            existingMessagesCount = 10_000
+
+            // when
+            val result = chatService.findRecentMessages(USER_ID, ROOM_ID, requestAmount)
+
+            // then
+            assertThat(result.size).isEqualTo(RECENT_MESSAGE_UPPER_BOUND)
+        }
+
+        @ParameterizedTest
+        @ValueSource(ints = [-100, -1, 0, 1])
+        fun `너무 적은 양의 메시지를 요청하면, 하한선만큼 제공한다`(requestAmount: Int) {
+            // given
+            existingMessagesCount = calculateEnoughMessagesCountBy(requestAmount)
+
+            // when
+            val result = chatService.findRecentMessages(USER_ID, ROOM_ID, requestAmount)
+
+            // then
+            assertThat(result.size).isEqualTo(RECENT_MESSAGE_LOWER_BOUND)
+        }
+    }
+
+    private fun createUserRoom(user: User, room: Room): UserRoom {
+        return UserRoom(
+            user = user,
+            room = room,
+            roomRole = RoomRole.MEMBER
+        )
+    }
+
+    private fun getChatSendRequestDto(): ChatSendRequestDto {
+        return ChatSendRequestDto(
+            content = "nope",
+            type = MessageType.TEXT,
+            clientMessageId = "client-2",
+            attachmentFileIdsInOrder = emptyList()
+        )
+    }
+
+    private fun calculateEnoughMessagesCountBy(requestAmount: Int): Int {
+        return requestAmount.coerceAtLeast(1) * 10
+    }
+}

--- a/src/test/kotlin/goodspace/teaming/chat/service/RoomAccessServiceTest.kt
+++ b/src/test/kotlin/goodspace/teaming/chat/service/RoomAccessServiceTest.kt
@@ -1,0 +1,42 @@
+package goodspace.teaming.chat.service
+
+import goodspace.teaming.global.repository.UserRoomRepository
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThatCode
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+private const val ROOM_ID = 10L
+private const val USER_ID = 5L
+private const val WRONG_ID = 99L
+
+class RoomAccessServiceTest {
+    private val userRoomRepository = mockk<UserRoomRepository>()
+    private val roomAccessService: RoomAccessAuthorizer = RoomAccessService(userRoomRepository)
+
+    @BeforeEach
+    fun mocking() {
+        every { userRoomRepository.existsByRoomIdAndUserId(any(), any()) } returns false
+        every { userRoomRepository.existsByRoomIdAndUserId(ROOM_ID, USER_ID) } returns true
+    }
+
+    @Nested
+    @DisplayName("assertMemberOf")
+    inner class AssertMemberOf {
+        @Test
+        fun `회원이 해당 티밍룸에 참여하고 있지 않다면 예외를 던진다`() {
+            assertThatThrownBy { roomAccessService.assertMemberOf(WRONG_ID, USER_ID) }
+                .isInstanceOf(IllegalArgumentException::class.java)
+        }
+
+        @Test
+        fun `회원이 해당 티밍룸에 참여하고 있다면 예외를 던지지 않는다`() {
+            assertThatCode { roomAccessService.assertMemberOf(ROOM_ID, USER_ID) }
+                .doesNotThrowAnyException()
+        }
+    }
+}

--- a/src/test/kotlin/goodspace/teaming/email/service/EmailVerificationServiceTest.kt
+++ b/src/test/kotlin/goodspace/teaming/email/service/EmailVerificationServiceTest.kt
@@ -4,8 +4,7 @@ import goodspace.teaming.email.dto.CodeSendRequestDto
 import goodspace.teaming.email.dto.EmailVerifyRequestDto
 import goodspace.teaming.email.event.EmailSendRequestEvent
 import goodspace.teaming.global.entity.email.EmailVerification
-import goodspace.teaming.global.entity.user.User
-import goodspace.teaming.global.entity.user.UserType
+import goodspace.teaming.global.entity.user.TeamingUser
 import goodspace.teaming.global.repository.EmailVerificationRepository
 import goodspace.teaming.global.repository.UserRepository
 import org.assertj.core.api.Assertions.assertThat
@@ -18,13 +17,13 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.event.ApplicationEvents
 import org.springframework.test.context.event.RecordApplicationEvents
 import org.springframework.transaction.annotation.Transactional
-import java.lang.IllegalStateException
 import java.time.LocalDateTime
 
 private const val NOT_EXIST_EMAIL = "notExist@email.com"
 private const val DEFAULT_EMAIL = "default@email.com"
 private const val DEFAULT_CODE = "defaultCode"
 private const val DEFAULT_NAME = "DEFAULT NAME"
+private const val DEFAULT_PASSWORD = "defaultPassword"
 
 @SpringBootTest
 @RecordApplicationEvents
@@ -58,10 +57,10 @@ class EmailVerificationServiceTest(
             // arrange
             val existEmail = "EXIST@email.com"
             userRepository.save(
-                User(
+                TeamingUser(
                     email = existEmail,
-                    name = DEFAULT_NAME,
-                    type = UserType.TEAMING
+                    password = DEFAULT_PASSWORD,
+                    name = DEFAULT_NAME
                 )
             )
 

--- a/src/test/kotlin/goodspace/teaming/fixture/FileFixture.kt
+++ b/src/test/kotlin/goodspace/teaming/fixture/FileFixture.kt
@@ -1,0 +1,74 @@
+package goodspace.teaming.fixture
+
+import goodspace.teaming.global.entity.file.AntiVirusScanStatus
+import goodspace.teaming.global.entity.file.File
+import goodspace.teaming.global.entity.file.FileType
+import goodspace.teaming.global.entity.file.TranscodeStatus
+import goodspace.teaming.global.entity.room.Room
+import goodspace.teaming.global.entity.user.User
+
+enum class FileFixture(
+    private val filename: String,
+    private val type: FileType,
+    private val mimeType: String,
+    private val byteSize: Long,
+    private val storageKey: String,
+    private val storageBucket: String,
+    private val checksumSha256: String,
+    private val width: Int? = null,
+    private val height: Int? = null,
+    private val durationMs: Int? = null,
+    private val thumbnailKey: String? = null,
+    private val antiVirusScanStatus: AntiVirusScanStatus,
+    private val transcodeStatus: TranscodeStatus
+) {
+    IMAGE(
+        filename = "imagefile",
+        type = FileType.IMAGE,
+        mimeType = "image/jpeg",
+        byteSize = 123,
+        storageKey = "imageStorageKey",
+        storageBucket = "imageStorageBuceket",
+        checksumSha256 = "imageChecksum",
+        width = 10,
+        height = 10,
+        thumbnailKey = "imageThumnail",
+        antiVirusScanStatus = AntiVirusScanStatus.PASSED,
+        transcodeStatus = TranscodeStatus.COMPLETED
+    ),
+    VIDEO(
+        filename = "videofile",
+        type = FileType.VIDEO,
+        mimeType = "video/mp4",
+        byteSize = 1_048_576, // 1MB
+        storageKey = "videoStorageKey",
+        storageBucket = "videoStorageBucket",
+        checksumSha256 = "videoChecksum",
+        width = 1920,
+        height = 1080,
+        durationMs = 120_000, // 2분
+        thumbnailKey = "videoThumbnailKey",
+        antiVirusScanStatus = AntiVirusScanStatus.PASSED,
+        transcodeStatus = TranscodeStatus.COMPLETED
+    );
+
+    fun getInstanceWith(room: Room, user: User): File {
+        return File(
+            room = room,
+            user = user,
+            name = filename,
+            type = type,
+            mimeType = mimeType,
+            byteSize = byteSize,
+            storageKey = storageKey,
+            storageBucket = storageBucket,
+            checksumSha256 = checksumSha256,
+            width = width,
+            height = height,
+            durationMs = durationMs,
+            thumbnailKey = thumbnailKey,
+            antiVirusScanStatus = antiVirusScanStatus,
+            transcodeStatus = transcodeStatus
+        )
+    }
+}

--- a/src/test/kotlin/goodspace/teaming/fixture/RoomFixture.kt
+++ b/src/test/kotlin/goodspace/teaming/fixture/RoomFixture.kt
@@ -1,0 +1,39 @@
+package goodspace.teaming.fixture
+
+import goodspace.teaming.global.entity.room.Room
+import goodspace.teaming.global.entity.room.RoomType
+
+enum class RoomFixture(
+    private val title: String,
+    private val type: RoomType,
+    private val inviteCode: String
+) {
+    DEFAULT(
+        "default title",
+        RoomType.BASIC,
+        "default invite"
+    ),
+    BASIC(
+        "basic title",
+        RoomType.BASIC,
+        "basic invite"
+    ),
+    STANDARD(
+        "stnadard title",
+        RoomType.STANDARD,
+        "standard invite"
+    ),
+    ELITE(
+        "elite title",
+        RoomType.ELITE,
+        "elite invite"
+    );
+
+    fun getInstance(): Room {
+        return Room(
+            title = title,
+            type = type,
+            inviteCode = inviteCode
+        )
+    }
+}

--- a/src/test/kotlin/goodspace/teaming/fixture/TeamingUserFixture.kt
+++ b/src/test/kotlin/goodspace/teaming/fixture/TeamingUserFixture.kt
@@ -1,0 +1,24 @@
+package goodspace.teaming.fixture
+
+import goodspace.teaming.global.entity.user.TeamingUser
+
+
+enum class TeamingUserFixture(
+    private val email: String,
+    private val password: String,
+    private val username: String,
+) {
+    A(
+        "a@email.com",
+        "aPassword",
+        "aUsername"
+    );
+
+    fun getInstance(): TeamingUser {
+        return TeamingUser(
+            email = email,
+            password = password,
+            name = username
+        )
+    }
+}

--- a/src/test/kotlin/goodspace/teaming/global/storage/CdnStorageUrlProviderTest.kt
+++ b/src/test/kotlin/goodspace/teaming/global/storage/CdnStorageUrlProviderTest.kt
@@ -1,0 +1,162 @@
+package goodspace.teaming.global.storage
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.net.URLDecoder
+import java.nio.charset.StandardCharsets
+
+private const val CDN_BASE = "https://cdn.base.com"
+private const val VERSION_PARAMETER_NAME = "v"
+private const val SIZE_PARAMETER_NAME = "s"
+private const val FILENAME_PARAMETER_NAME = "filename"
+
+private const val DEFAULT_KEY = "defaultKey"
+private const val DEFAULT_VERSION = 5
+private const val DEFAULT_SIZE = 100
+private const val DEFAULT_FILE_NAME = "file.pdf"
+
+class CdnStorageUrlProviderTest {
+    private val cdnStorageUrlProvider = CdnStorageUrlProvider(
+        cdnBase =  CDN_BASE,
+        versionParameterName =  VERSION_PARAMETER_NAME,
+        sizeParameterName =  SIZE_PARAMETER_NAME,
+        filenameParameterName =  FILENAME_PARAMETER_NAME
+    )
+
+    @Nested
+    @DisplayName("publicUrl")
+    inner class PublicUrl {
+        @Test
+        fun `key 값이 null이라면 null을 반환한다`() {
+            val url = cdnStorageUrlProvider.publicUrl(
+                key = null,
+                version = DEFAULT_VERSION,
+                size = DEFAULT_SIZE
+            )
+
+            assertThat(url).isNull()
+        }
+
+        @Test
+        fun `key 값이 null이 아니라면 null을 반환하지 않는다`() {
+            val url = cdnStorageUrlProvider.publicUrl(
+                key = DEFAULT_KEY,
+                version = null,
+                size = null
+            )
+
+            assertThat(url).isNotNull()
+        }
+
+        @Test
+        fun `버전, 사이즈 정보는 쿼리 스트링에 담긴다`() {
+            val url = cdnStorageUrlProvider.publicUrl(
+                key = DEFAULT_KEY,
+                version = DEFAULT_VERSION,
+                size = DEFAULT_SIZE,
+            )!!
+
+            val queryString = getQueryString(url)
+            val params = parseQueryString(queryString)
+
+            assertThat(params[VERSION_PARAMETER_NAME]).isEqualTo(DEFAULT_VERSION.toString())
+            assertThat(params[SIZE_PARAMETER_NAME]).isEqualTo(DEFAULT_SIZE.toString())
+        }
+
+        @Test
+        fun `파라미터가 없으면 쿼리 스트링을 생성하지 않는다`() {
+            val url = cdnStorageUrlProvider.downloadUrl(
+                key = DEFAULT_KEY,
+                filename = null,
+                version = null
+            )!!
+
+            assertThat(url).isNotEmpty()
+            assertThat(getQueryString(url)).isEmpty()
+        }
+    }
+
+    @Nested
+    @DisplayName("downloadUrl")
+    inner class DownloadUrl {
+        @Test
+        fun `key 값이 null이라면 null을 반환한다`() {
+            val url = cdnStorageUrlProvider.downloadUrl(
+                key = null,
+                filename = DEFAULT_FILE_NAME,
+                version = DEFAULT_VERSION
+            )
+
+            assertThat(url).isNull()
+        }
+
+        @Test
+        fun `key 값이 null이 아니라면 null을 반환하지 않는다`() {
+            val url = cdnStorageUrlProvider.downloadUrl(
+                key = DEFAULT_KEY,
+                filename = null,
+                version = null
+            )
+
+            assertThat(url).isNotNull()
+        }
+
+        @Test
+        fun `파일명, 버전 정보는 쿼리 스트링에 담긴다`() {
+            val url = cdnStorageUrlProvider.downloadUrl(
+                key = DEFAULT_KEY,
+                filename = DEFAULT_FILE_NAME,
+                version = DEFAULT_VERSION
+            )!!
+
+            val queryString = getQueryString(url)
+            val params = parseQueryString(queryString)
+
+            assertThat(params[FILENAME_PARAMETER_NAME]).isEqualTo(DEFAULT_FILE_NAME)
+            assertThat(params[VERSION_PARAMETER_NAME]).isEqualTo(DEFAULT_VERSION.toString())
+        }
+
+        @Test
+        fun `파라미터가 전혀 없으면 쿼리스트링 없이 반환한다`() {
+            val url = cdnStorageUrlProvider.downloadUrl(
+                key = DEFAULT_KEY,
+                filename = null,
+                version = null
+            )!!
+
+            assertThat(url).isNotEmpty()
+            assertThat(getQueryString(url)).isEmpty()
+        }
+    }
+
+    private fun getQueryString(url: String): String {
+        val queryDelimiter = "?"
+
+        if (!url.contains(queryDelimiter)) {
+            return ""
+        }
+
+        return url.substringAfter(queryDelimiter)
+    }
+
+    private fun parseQueryString(queryString: String): Map<String, String> {
+        if (queryString.isBlank()) return emptyMap()
+
+        val result = LinkedHashMap<String, String>()
+        queryString.split('&')
+            .filter { it.isNotBlank() }
+            .forEach { pair ->
+                val indexOfSeparator = pair.indexOf('=')
+                val rawKey = if (indexOfSeparator >= 0) pair.substring(0, indexOfSeparator) else pair
+                val rawVal = if (indexOfSeparator >= 0) pair.substring(indexOfSeparator + 1) else ""
+                val key = URLDecoder.decode(rawKey, StandardCharsets.UTF_8)
+                val value = URLDecoder.decode(rawVal, StandardCharsets.UTF_8)
+
+                result[key] = value
+            }
+
+        return result
+    }
+}


### PR DESCRIPTION
## 🔍 개요
<!--
  무엇을 변경했나요?
  왜 변경했나요? (이유/동기/관련 테켓)
-->
- 웹소캣을 설정했습니다.
- 웹소캣을 적용한 채팅 API를 구현했습니다.
- 테스트 코드를 작성했습니다.
- 어색하거나 부적절했던 엔티티 클래스를 수정했습니다.

## 🔗 관련 이슈
<!--
  이슈 번호 및 링크
-->
#1 

## 📝 참고할 사항
- 채팅방 CRUD가 구축되어 있지 않기 때문에, 모든 테스트는 테스트 코드상으로만 수행했습니다.
