### PR TITLE
[feat/#15] 티밍룸 API 구현 및 기존 채팅 로직 개선

### DIFF
--- a/src/main/kotlin/goodspace/teaming/TeamingApplication.kt
+++ b/src/main/kotlin/goodspace/teaming/TeamingApplication.kt
@@ -3,9 +3,11 @@ package goodspace.teaming
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.runApplication
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing
+import org.springframework.retry.annotation.EnableRetry
 
 @SpringBootApplication
 @EnableJpaAuditing
+@EnableRetry
 class TeamingApplication
 
 fun main(args: Array<String>) {

--- a/src/main/kotlin/goodspace/teaming/chat/controller/ChatWsController.kt
+++ b/src/main/kotlin/goodspace/teaming/chat/controller/ChatWsController.kt
@@ -1,7 +1,7 @@
 package goodspace.teaming.chat.controller
 
 import goodspace.teaming.chat.dto.ChatSendRequestDto
-import goodspace.teaming.chat.service.ChatService
+import goodspace.teaming.chat.service.MessageService
 import goodspace.teaming.global.security.getUserId
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.messaging.handler.annotation.DestinationVariable
@@ -12,18 +12,19 @@ import org.springframework.messaging.simp.SimpMessagingTemplate
 import org.springframework.stereotype.Controller
 import java.security.Principal
 
-private const val PREFIX = "rooms"
-
 @Controller
-@MessageMapping(PREFIX)
+@MessageMapping("/rooms")
 @Tag(
     name = "채팅 API (웹소캣)",
     description = "AsyncAPI 문서 링크 첨부 예정"
 )
 class ChatWsController(
-    private val chatService: ChatService,
+    private val messageService: MessageService,
     private val messaging: SimpMessagingTemplate
 ) {
+    /**
+     * 메시지 생성
+     */
     @MessageMapping("/{roomId}/send")
     fun sendMessage(
         @DestinationVariable roomId: Long,
@@ -32,9 +33,7 @@ class ChatWsController(
     ) {
         val senderId = principal.getUserId()
 
-        val savedMessage = chatService.saveMessage(senderId, roomId, requestDto)
-
-        messaging.convertAndSend("/topic/$PREFIX/$roomId", savedMessage)
+        messageService.saveMessage(senderId, roomId, requestDto)
     }
 
     /**

--- a/src/main/kotlin/goodspace/teaming/chat/domain/InviteCodeGenerator.kt
+++ b/src/main/kotlin/goodspace/teaming/chat/domain/InviteCodeGenerator.kt
@@ -1,0 +1,25 @@
+package goodspace.teaming.chat.domain
+
+import org.springframework.stereotype.Component
+import java.security.SecureRandom
+
+private const val SHORT_LENGTH = "지정된 코드 길이가 너무 짧습니다."
+private const val INSUFFICIENT_CHARACTERS = "허용된 문자가 너무 적습니다."
+
+@Component
+class InviteCodeGenerator(
+    private val codeLength: Int = 10,
+    private val allowedCharacters: String = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789",
+    private val random: SecureRandom = SecureRandom()
+) {
+    init {
+        require(codeLength > 0) { SHORT_LENGTH }
+        require(allowedCharacters.isNotEmpty()) { INSUFFICIENT_CHARACTERS }
+    }
+
+    fun generate(): String = buildString(codeLength) {
+        repeat(codeLength) {
+            append(allowedCharacters[random.nextInt(allowedCharacters.length)])
+        }
+    }
+}

--- a/src/main/kotlin/goodspace/teaming/chat/domain/mapper/RoomInfoMapper.kt
+++ b/src/main/kotlin/goodspace/teaming/chat/domain/mapper/RoomInfoMapper.kt
@@ -1,0 +1,39 @@
+package goodspace.teaming.chat.domain.mapper
+
+import goodspace.teaming.chat.dto.RoomInfoResponseDto
+import goodspace.teaming.global.entity.room.UserRoom
+import goodspace.teaming.global.repository.MessageRepository
+
+class RoomInfoMapper(
+    private val messageRepository: MessageRepository,
+    private val lastMessagePreviewMapper: LastMessagePreviewMapper
+)  {
+    fun map(userRoom: UserRoom): RoomInfoResponseDto {
+        val lastReadMessageId = userRoom.lastReadMessageId
+
+        val unreadCount = messageRepository.countUnreadInRoom(
+            room = userRoom.room,
+            user = userRoom.user,
+            lastReadMessageId = lastReadMessageId
+        )
+
+        val lastMessageDto = lastReadMessageId
+            ?.let(messageRepository::findById)
+            ?.map { lastMessagePreviewMapper.map(it) }
+            ?.orElse(null)
+
+        val room = userRoom.room
+
+        return RoomInfoResponseDto(
+            roomId = room.id!!,
+            unreadCount = unreadCount,
+            lastMessage = lastMessageDto,
+            title = room.title,
+            imageKey = room.imageKey,
+            imageVersion = room.imageVersion,
+            type = room.type,
+            memberCount = room.memberCount,
+            success = room.success
+        )
+    }
+}

--- a/src/main/kotlin/goodspace/teaming/chat/domain/mapper/RoomMapper.kt
+++ b/src/main/kotlin/goodspace/teaming/chat/domain/mapper/RoomMapper.kt
@@ -1,0 +1,18 @@
+package goodspace.teaming.chat.domain.mapper
+
+import goodspace.teaming.chat.dto.RoomCreateRequestDto
+import goodspace.teaming.global.entity.room.Room
+import org.springframework.stereotype.Component
+
+@Component
+class RoomMapper{
+    fun map(dto: RoomCreateRequestDto): Room {
+        return Room(
+            title = dto.title,
+            imageKey = dto.imageKey,
+            imageVersion = dto.imageVersion,
+            type = dto.roomType,
+            memberCount = dto.memberCount
+        )
+    }
+}

--- a/src/main/kotlin/goodspace/teaming/chat/dto/InviteAcceptRequestDto.kt
+++ b/src/main/kotlin/goodspace/teaming/chat/dto/InviteAcceptRequestDto.kt
@@ -1,0 +1,5 @@
+package goodspace.teaming.chat.dto
+
+data class InviteAcceptRequestDto(
+    val inviteCode: String
+)

--- a/src/main/kotlin/goodspace/teaming/chat/dto/ReadBoundaryUpdateResponseDto.kt
+++ b/src/main/kotlin/goodspace/teaming/chat/dto/ReadBoundaryUpdateResponseDto.kt
@@ -1,0 +1,7 @@
+package goodspace.teaming.chat.dto
+
+data class ReadBoundaryUpdateResponseDto(
+    val userId: Long,
+    val lastReadMessageId: Long?,
+    val unreadCount: Long
+)

--- a/src/main/kotlin/goodspace/teaming/chat/dto/RoomCreateRequestDto.kt
+++ b/src/main/kotlin/goodspace/teaming/chat/dto/RoomCreateRequestDto.kt
@@ -1,0 +1,12 @@
+package goodspace.teaming.chat.dto
+
+import goodspace.teaming.global.entity.room.RoomType
+
+data class RoomCreateRequestDto(
+    val title: String,
+    val description: String,
+    val memberCount: Int,
+    val roomType: RoomType,
+    val imageKey: String?,
+    val imageVersion: Int?
+)

--- a/src/main/kotlin/goodspace/teaming/chat/dto/RoomInfoResponseDto.kt
+++ b/src/main/kotlin/goodspace/teaming/chat/dto/RoomInfoResponseDto.kt
@@ -1,0 +1,15 @@
+package goodspace.teaming.chat.dto
+
+import goodspace.teaming.global.entity.room.RoomType
+
+data class RoomInfoResponseDto(
+    val roomId: Long,
+    val unreadCount: Long,
+    val lastMessage: LastMessagePreviewResponseDto?,
+    val title: String,
+    val imageKey: String?,
+    val imageVersion: Int?,
+    val type: RoomType,
+    val memberCount: Int,
+    val success: Boolean
+)

--- a/src/main/kotlin/goodspace/teaming/chat/event/ReadBoundUpdateEventHandler.kt
+++ b/src/main/kotlin/goodspace/teaming/chat/event/ReadBoundUpdateEventHandler.kt
@@ -1,0 +1,24 @@
+package goodspace.teaming.chat.event
+
+import goodspace.teaming.chat.dto.ReadBoundaryUpdateResponseDto
+import org.springframework.messaging.simp.SimpMessagingTemplate
+import org.springframework.stereotype.Component
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+
+@Component
+class ReadBoundUpdateEventHandler(
+    private val messaging: SimpMessagingTemplate
+) {
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun onReadBoundaryUpdated(event: ReadBoundaryUpdateEvent) {
+        messaging.convertAndSend(
+            "/topic/rooms/${event.roomId}/read",
+            ReadBoundaryUpdateResponseDto(
+                userId = event.userId,
+                lastReadMessageId = event.lastReadMessageId,
+                unreadCount = event.unreadCount
+            )
+        )
+    }
+}

--- a/src/main/kotlin/goodspace/teaming/chat/event/ReadBoundaryUpdateEvent.kt
+++ b/src/main/kotlin/goodspace/teaming/chat/event/ReadBoundaryUpdateEvent.kt
@@ -1,0 +1,8 @@
+package goodspace.teaming.chat.event
+
+data class ReadBoundaryUpdateEvent(
+    val roomId: Long,
+    val userId: Long,
+    val lastReadMessageId: Long?,
+    val unreadCount: Long
+)

--- a/src/main/kotlin/goodspace/teaming/chat/exception/InviteCodeAllocationFailedException.kt
+++ b/src/main/kotlin/goodspace/teaming/chat/exception/InviteCodeAllocationFailedException.kt
@@ -1,0 +1,10 @@
+package goodspace.teaming.chat.exception
+
+import org.springframework.http.HttpStatus
+import org.springframework.web.bind.annotation.ResponseStatus
+import java.lang.RuntimeException
+
+@ResponseStatus(HttpStatus.SERVICE_UNAVAILABLE)
+class InviteCodeAllocationFailedException(
+    override val message: String = "유일한 초대 코드를 생성하는 데 실패했습니다."
+) : RuntimeException(message)

--- a/src/main/kotlin/goodspace/teaming/chat/service/MessageService.kt
+++ b/src/main/kotlin/goodspace/teaming/chat/service/MessageService.kt
@@ -4,7 +4,7 @@ import goodspace.teaming.chat.dto.ChatMessagePageResponseDto
 import goodspace.teaming.chat.dto.ChatMessageResponseDto
 import goodspace.teaming.chat.dto.ChatSendRequestDto
 
-interface ChatService {
+interface MessageService {
     fun saveMessage(
         userId: Long,
         roomId: Long,

--- a/src/main/kotlin/goodspace/teaming/chat/service/RoomAccessService.kt
+++ b/src/main/kotlin/goodspace/teaming/chat/service/RoomAccessService.kt
@@ -3,11 +3,13 @@ package goodspace.teaming.chat.service
 import goodspace.teaming.global.repository.UserRoomRepository
 import org.springframework.stereotype.Service
 
+private const val USER_ROOM_NOT_FOUND = "해당 방에 소속되지 않았습니다."
+
 @Service
 class RoomAccessService(
     private val userRoomRepository: UserRoomRepository
 ) : RoomAccessAuthorizer {
     override fun assertMemberOf(roomId: Long, userId: Long) {
-        require(userRoomRepository.existsByRoomIdAndUserId(roomId, userId)) { "해당 방에 대한 구독 권한이 없습니다." }
+        require(userRoomRepository.existsByRoomIdAndUserId(roomId, userId)) { USER_ROOM_NOT_FOUND }
     }
 }

--- a/src/main/kotlin/goodspace/teaming/chat/service/RoomService.kt
+++ b/src/main/kotlin/goodspace/teaming/chat/service/RoomService.kt
@@ -1,0 +1,31 @@
+package goodspace.teaming.chat.service
+
+import goodspace.teaming.chat.dto.InviteAcceptRequestDto
+import goodspace.teaming.chat.dto.RoomCreateRequestDto
+import goodspace.teaming.chat.dto.RoomInfoResponseDto
+
+interface RoomService {
+    fun createRoom(
+        userId: Long,
+        requestDto: RoomCreateRequestDto
+    )
+
+    fun acceptInvite(
+        userId: Long,
+        requestDto: InviteAcceptRequestDto
+    ): RoomInfoResponseDto
+
+    fun getRooms(
+        userId: Long
+    ): List<RoomInfoResponseDto>
+
+    fun leaveRoom(
+        userId: Long,
+        roomId: Long
+    )
+
+    fun setSuccess(
+        userId: Long,
+        roomId: Long
+    )
+}

--- a/src/main/kotlin/goodspace/teaming/chat/service/RoomServiceImpl.kt
+++ b/src/main/kotlin/goodspace/teaming/chat/service/RoomServiceImpl.kt
@@ -1,0 +1,137 @@
+package goodspace.teaming.chat.service
+
+import goodspace.teaming.chat.domain.InviteCodeGenerator
+import goodspace.teaming.chat.domain.mapper.RoomInfoMapper
+import goodspace.teaming.chat.domain.mapper.RoomMapper
+import goodspace.teaming.chat.dto.InviteAcceptRequestDto
+import goodspace.teaming.chat.dto.RoomCreateRequestDto
+import goodspace.teaming.chat.dto.RoomInfoResponseDto
+import goodspace.teaming.chat.exception.InviteCodeAllocationFailedException
+import goodspace.teaming.global.entity.room.PaymentStatus
+import goodspace.teaming.global.entity.room.RoomRole
+import goodspace.teaming.global.entity.room.UserRoom
+import goodspace.teaming.global.repository.RoomRepository
+import goodspace.teaming.global.repository.UserRepository
+import goodspace.teaming.global.repository.UserRoomRepository
+import org.springframework.dao.DataIntegrityViolationException
+import org.springframework.retry.annotation.Backoff
+import org.springframework.retry.annotation.Retryable
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+private const val USER_NOT_FOUND = "회원을 조회할 수 없습니다."
+private const val ROOM_NOT_FOUND = "티밍룸을 조회할 수 없습니다."
+private const val ALREADY_JOINED = "이미 해방 티밍룸에 소속되어 있습니다."
+private const val WRONG_INVITE_CODE = "부적절한 초대 코드입니다."
+private const val NOT_PAID = "결제되지 않았습니다."
+private const val NOT_LEADER = "팀장이 아닙니다."
+
+@Service
+class RoomServiceImpl(
+    private val userRepository: UserRepository,
+    private val roomRepository: RoomRepository,
+    private val userRoomRepository: UserRoomRepository,
+    private val roomMapper: RoomMapper,
+    private val roomInfoMapper: RoomInfoMapper,
+    private val inviteCodeGenerator: InviteCodeGenerator
+) : RoomService {
+    @Transactional
+    @Retryable(
+        include = [DataIntegrityViolationException::class, InviteCodeAllocationFailedException::class],
+        maxAttempts = 3,
+        backoff = Backoff(delay = 50, multiplier = 2.0)
+    )
+    override fun createRoom(userId: Long, requestDto: RoomCreateRequestDto) {
+        val user = userRepository.findById(userId).orElse(null)
+            ?: throw IllegalArgumentException(USER_NOT_FOUND)
+
+        val room = roomMapper.map(requestDto)
+        room.inviteCode = getUniqueInviteCode()
+
+        val userRoom = UserRoom(
+            user = user,
+            room = room,
+            roomRole = RoomRole.LEADER
+        )
+        room.addUserRoom(userRoom)
+
+        // 초대 코드가 중복될 시 재시도하기 위한 플러쉬
+        roomRepository.saveAndFlush(room)
+    }
+
+    @Transactional
+    override fun acceptInvite(userId: Long, requestDto: InviteAcceptRequestDto): RoomInfoResponseDto {
+        val user = userRepository.findById(userId).orElse(null)
+            ?: throw IllegalArgumentException(USER_NOT_FOUND)
+        val room = roomRepository.findByInviteCode(requestDto.inviteCode)
+            ?: throw IllegalArgumentException(WRONG_INVITE_CODE)
+
+        require(!userRoomRepository.existsByRoomAndUser(room, user)) { ALREADY_JOINED }
+
+        val userRoom = UserRoom(
+            user = user,
+            room = room,
+            roomRole = RoomRole.MEMBER,
+        )
+        user.addUserRoom(userRoom)
+        room.addUserRoom(userRoom)
+
+        return roomInfoMapper.map(userRoom)
+    }
+
+    @Transactional(readOnly = true)
+    override fun getRooms(userId: Long): List<RoomInfoResponseDto> {
+        val user = userRepository.findById(userId).orElse(null)
+            ?: throw IllegalArgumentException(USER_NOT_FOUND)
+
+        return user.userRooms
+            .map { roomInfoMapper.map(it) }
+    }
+
+    @Transactional
+    override fun leaveRoom(userId: Long, roomId: Long) {
+        val userRoom = userRoomRepository.findByRoomIdAndUserId(roomId, userId)
+            ?: throw IllegalArgumentException(ROOM_NOT_FOUND)
+        val room = userRoom.room
+
+        require(userRoom.paymentStatus != PaymentStatus.NOT_PAID) { NOT_PAID }
+
+        if (userRoom.paymentStatus == PaymentStatus.PAID) {
+            // TODO: 벌칙 이벤트 발생
+        }
+
+        room.removeUserRoom(userRoom)
+
+        if (room.isEmpty()) {
+            roomRepository.delete(room)
+        }
+    }
+
+    @Transactional
+    override fun setSuccess(userId: Long, roomId: Long) {
+        val userRoom = userRoomRepository.findByRoomIdAndUserId(roomId, userId)
+            ?: throw IllegalArgumentException(ROOM_NOT_FOUND)
+        val room = userRoom.room
+
+        check(userRoom.roomRole == RoomRole.LEADER) { NOT_LEADER }
+
+        // TODO 환불 이벤트 발생
+
+        room.success = true
+    }
+
+    private fun getUniqueInviteCode(): String {
+        var tryCount = 0
+
+        while (tryCount < 10) {
+            val inviteCode = inviteCodeGenerator.generate()
+
+            if (!roomRepository.existsByInviteCode(inviteCode)) {
+                return inviteCode
+            }
+            tryCount++
+        }
+
+        throw InviteCodeAllocationFailedException()
+    }
+}

--- a/src/main/kotlin/goodspace/teaming/global/entity/room/PaymentStatus.kt
+++ b/src/main/kotlin/goodspace/teaming/global/entity/room/PaymentStatus.kt
@@ -1,0 +1,5 @@
+package goodspace.teaming.global.entity.room
+
+enum class PaymentStatus {
+    NOT_PAID, PAID, REFUNDED
+}

--- a/src/main/kotlin/goodspace/teaming/global/entity/room/Room.kt
+++ b/src/main/kotlin/goodspace/teaming/global/entity/room/Room.kt
@@ -2,10 +2,13 @@ package goodspace.teaming.global.entity.room
 
 import goodspace.teaming.global.entity.BaseEntity
 import jakarta.persistence.*
+import jakarta.persistence.CascadeType.*
 import jakarta.persistence.EnumType.*
+import jakarta.persistence.FetchType.*
 import jakarta.persistence.GenerationType.IDENTITY
 import org.hibernate.annotations.SQLDelete
 import org.hibernate.annotations.SQLRestriction
+import java.lang.IllegalStateException
 
 @Entity
 @Table(name = "`room`")
@@ -15,16 +18,40 @@ class Room(
     @Column(nullable = false)
     var title: String,
 
-    var image: ByteArray? = null,
+    var imageKey: String? = null,
+
+    var imageVersion: Int? = null,
 
     @Enumerated(STRING)
     @Column(nullable = false)
     val type: RoomType,
 
-    @Column(nullable = false, unique = true)
-    var inviteCode: String
+    @Column(unique = true)
+    var inviteCode: String? = null,
+
+    @Column(nullable = false)
+    val memberCount: Int
 ) : BaseEntity() {
     @Id
     @GeneratedValue(strategy = IDENTITY)
     val id: Long? = null
+
+    @OneToMany(fetch = LAZY, mappedBy = "room", cascade = [ALL], orphanRemoval = true)
+    val userRooms: MutableList<UserRoom> = mutableListOf()
+
+    var success: Boolean = false
+
+    fun isEmpty(): Boolean {
+        return userRooms.isEmpty()
+    }
+
+    fun addUserRoom(userRoom: UserRoom) {
+        require(userRooms.size <= memberCount) { throw IllegalStateException("방의 최대 인원 수를 초과했습니다.") }
+
+        userRooms.add(userRoom)
+    }
+
+    fun removeUserRoom(userRoom: UserRoom) {
+        userRooms.remove(userRoom)
+    }
 }

--- a/src/main/kotlin/goodspace/teaming/global/entity/room/UserRoom.kt
+++ b/src/main/kotlin/goodspace/teaming/global/entity/room/UserRoom.kt
@@ -4,6 +4,7 @@ import goodspace.teaming.global.entity.BaseEntity
 import goodspace.teaming.global.entity.user.User
 import jakarta.persistence.*
 import jakarta.persistence.EnumType.*
+import jakarta.persistence.FetchType.*
 import jakarta.persistence.GenerationType.*
 import org.hibernate.annotations.SQLDelete
 import org.hibernate.annotations.SQLRestriction
@@ -12,11 +13,11 @@ import org.hibernate.annotations.SQLRestriction
 @SQLDelete(sql = "UPDATE user_room SET deleted = true, deleted_at = NOW() WHERE id = ?")
 @SQLRestriction("deleted = false")
 class UserRoom(
-    @ManyToOne
+    @ManyToOne(fetch = LAZY)
     @JoinColumn(nullable = false)
     val user: User,
 
-    @ManyToOne
+    @ManyToOne(fetch = LAZY)
     @JoinColumn(nullable = false)
     val room: Room,
 
@@ -27,7 +28,7 @@ class UserRoom(
     var lastReadMessageId: Long? = null,
 
     @Column(nullable = false)
-    val paid: Boolean = false
+    var paymentStatus: PaymentStatus = PaymentStatus.NOT_PAID
 ) : BaseEntity() {
     @Id
     @GeneratedValue(strategy = IDENTITY)

--- a/src/main/kotlin/goodspace/teaming/global/entity/user/User.kt
+++ b/src/main/kotlin/goodspace/teaming/global/entity/user/User.kt
@@ -1,9 +1,12 @@
 package goodspace.teaming.global.entity.user
 
 import goodspace.teaming.global.entity.BaseEntity
+import goodspace.teaming.global.entity.room.UserRoom
 import goodspace.teaming.global.security.RefreshToken
 import jakarta.persistence.*
+import jakarta.persistence.CascadeType.*
 import jakarta.persistence.EnumType.*
+import jakarta.persistence.FetchType.*
 import jakarta.persistence.GenerationType.*
 import org.hibernate.annotations.SQLDelete
 import org.hibernate.annotations.SQLRestriction
@@ -32,12 +35,19 @@ abstract class User(
     @GeneratedValue(strategy = IDENTITY)
     val id: Long? = null
 
-    @OneToOne(cascade = [CascadeType.ALL], orphanRemoval = true)
+    @OneToOne(fetch = LAZY, cascade = [ALL], orphanRemoval = true)
     private val refreshToken: RefreshToken = RefreshToken()
+
+    @OneToMany(mappedBy = "user", fetch = LAZY, cascade = [ALL], orphanRemoval = true)
+    val userRooms = mutableListOf<UserRoom>()
 
     var token = refreshToken.tokenValue
         set(value) {
             field = value
             refreshToken.tokenValue = value
         }
+
+    fun addUserRoom(userRoom: UserRoom) {
+        userRooms.add(userRoom)
+    }
 }

--- a/src/main/kotlin/goodspace/teaming/global/repository/RoomRepository.kt
+++ b/src/main/kotlin/goodspace/teaming/global/repository/RoomRepository.kt
@@ -3,4 +3,7 @@ package goodspace.teaming.global.repository
 import goodspace.teaming.global.entity.room.Room
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface RoomRepository : JpaRepository<Room, Long>
+interface RoomRepository : JpaRepository<Room, Long> {
+    fun existsByInviteCode(inviteCode: String): Boolean
+    fun findByInviteCode(inviteCode: String): Room?
+}

--- a/src/main/kotlin/goodspace/teaming/global/repository/UserRoomRepository.kt
+++ b/src/main/kotlin/goodspace/teaming/global/repository/UserRoomRepository.kt
@@ -1,6 +1,8 @@
 package goodspace.teaming.global.repository
 
+import goodspace.teaming.global.entity.room.Room
 import goodspace.teaming.global.entity.room.UserRoom
+import goodspace.teaming.global.entity.user.User
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Modifying
 import org.springframework.data.jpa.repository.Query
@@ -10,6 +12,8 @@ interface UserRoomRepository : JpaRepository<UserRoom, Long> {
     fun findByRoomIdAndUserId(roomId: Long, userId: Long): UserRoom?
 
     fun existsByRoomIdAndUserId(roomId: Long, userId: Long): Boolean
+
+    fun existsByRoomAndUser(room: Room, user: User): Boolean
 
     fun findByUserId(userId: Long): List<UserRoom>
 

--- a/src/test/kotlin/goodspace/teaming/chat/domain/InviteCodeGeneratorTest.kt
+++ b/src/test/kotlin/goodspace/teaming/chat/domain/InviteCodeGeneratorTest.kt
@@ -1,0 +1,54 @@
+package goodspace.teaming.chat.domain
+
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+private const val DEFAULT_CODE_LENGTH = 100
+
+class InviteCodeGeneratorTest {
+    @ParameterizedTest
+    @ValueSource(ints = [1, 10, 100, 1000])
+    fun `지정한 길이의 코드를 생성한다`(codeLength: Int) {
+        // given
+        val inviteCodeGenerator = InviteCodeGenerator(codeLength = codeLength)
+
+        // when
+        val code = inviteCodeGenerator.generate()
+
+        // then
+        assertThat(code.length).isEqualTo(codeLength)
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = ["a", "abc", "abcde", "abcdefg"])
+    fun `지정한 문자들만 포함한 코드를 생성한다`(allowedCharacters: String) {
+        // given
+        val inviteCodeGenerator = InviteCodeGenerator(
+            codeLength = DEFAULT_CODE_LENGTH,
+            allowedCharacters = allowedCharacters
+        )
+
+        // when
+        val code = inviteCodeGenerator.generate()
+
+        // then
+        val allowedCharacterSet = allowedCharacters.toSet()
+        assertThat(code.all { it in allowedCharacterSet }).isTrue()
+    }
+
+    @ParameterizedTest
+    @ValueSource(ints = [-100, -10, 0])
+    fun `문자 길이가 0 이하면 예외가 발생한다`(illegalCodeLength: Int) {
+        assertThatThrownBy { InviteCodeGenerator(codeLength = illegalCodeLength) }
+            .isInstanceOf(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun `허용 문자가 비어 있다면 예외가 발생한다`() {
+        assertThatThrownBy { InviteCodeGenerator(allowedCharacters = "") }
+            .isInstanceOf(IllegalArgumentException::class.java)
+    }
+}

--- a/src/test/kotlin/goodspace/teaming/chat/domain/mapper/RoomInfoMapperTest.kt
+++ b/src/test/kotlin/goodspace/teaming/chat/domain/mapper/RoomInfoMapperTest.kt
@@ -1,0 +1,133 @@
+package goodspace.teaming.chat.domain.mapper
+
+import goodspace.teaming.chat.dto.LastMessagePreviewResponseDto
+import goodspace.teaming.chat.dto.RoomInfoResponseDto
+import goodspace.teaming.global.entity.room.Message
+import goodspace.teaming.global.entity.room.Room
+import goodspace.teaming.global.entity.room.RoomType
+import goodspace.teaming.global.entity.room.UserRoom
+import goodspace.teaming.global.entity.user.User
+import goodspace.teaming.global.repository.MessageRepository
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.util.*
+
+private const val TITLE = "프로젝트 A"
+private const val IMAGE_KEY = "images/123.png"
+private const val IMAGE_VERSION = 10
+private const val MEMBER_COUNT = 5
+private val ROOM_TYPE = RoomType.BASIC
+private const val ROOM_ID = 100L
+private const val LAST_READ_MESSAGE_ID = 777L
+private const val UNREAD_COUNT = 7L
+private const val SUCCESS = false
+
+class RoomInfoMapperTest {
+
+    private lateinit var messageRepository: MessageRepository
+    private lateinit var lastMessagePreviewMapper: LastMessagePreviewMapper
+    private lateinit var roomInfoMapper: RoomInfoMapper
+
+    @BeforeEach
+    fun setUp() {
+        messageRepository = mockk(relaxed = true)
+        lastMessagePreviewMapper = mockk(relaxed = true)
+        roomInfoMapper = RoomInfoMapper(messageRepository, lastMessagePreviewMapper)
+    }
+
+    @Test
+    fun `lastReadMessageId가 있으면, 마지막 메시지에 대한 DTO를 포함해 매핑한다`() {
+        // given
+        val room = mockRoom()
+        val user = mockk<User>(relaxed = true)
+        val userRoom = mockk<UserRoom>(relaxed = true) {
+            every { this@mockk.room } returns room
+            every { this@mockk.user } returns user
+            every { this@mockk.lastReadMessageId } returns LAST_READ_MESSAGE_ID
+        }
+
+        val message = mockk<Message>()
+        val previewDto = mockk<LastMessagePreviewResponseDto>()
+
+        every {
+            messageRepository.countUnreadInRoom(room = room, user = user, lastReadMessageId = LAST_READ_MESSAGE_ID)
+        } returns UNREAD_COUNT
+
+        every { messageRepository.findById(LAST_READ_MESSAGE_ID) } returns Optional.of(message)
+        every { lastMessagePreviewMapper.map(message) } returns previewDto
+
+        // when
+        val result: RoomInfoResponseDto = roomInfoMapper.map(userRoom)
+
+        // then
+        assertThat(result.roomId).isEqualTo(ROOM_ID)
+        assertThat(result.unreadCount).isEqualTo(UNREAD_COUNT)
+        assertThat(result.lastMessage).isSameAs(previewDto)
+        assertThat(result.title).isEqualTo(TITLE)
+        assertThat(result.imageKey).isEqualTo(IMAGE_KEY)
+        assertThat(result.imageVersion).isEqualTo(IMAGE_VERSION)
+        assertThat(result.type).isEqualTo(ROOM_TYPE)
+        assertThat(result.memberCount).isEqualTo(MEMBER_COUNT)
+        assertThat(result.success).isEqualTo(SUCCESS)
+    }
+
+    @Test
+    fun `lastReadMessageId가 null이면, 마지막 메시지에 대한 DTO는 null이 된다`() {
+        // given
+        val room = mockRoom()
+        val user = mockk<User>(relaxed = true)
+        val userRoom = mockk<UserRoom>(relaxed = true) {
+            every { this@mockk.room } returns room
+            every { this@mockk.user } returns user
+            every { this@mockk.lastReadMessageId } returns null
+        }
+
+        // when
+        val result = roomInfoMapper.map(userRoom)
+
+        // then
+        assertThat(result.lastMessage).isNull()
+    }
+
+    @Test
+    fun `마지맛 메시지가 null이더라도 나머지 속성은 정상적으로 매핑된다`() {
+        // given
+        val room = mockRoom()
+        val user = mockk<User>(relaxed = true)
+        val userRoom = mockk<UserRoom>(relaxed = true) {
+            every { this@mockk.room } returns room
+            every { this@mockk.user } returns user
+            every { this@mockk.lastReadMessageId } returns LAST_READ_MESSAGE_ID
+        }
+
+        every { messageRepository.countUnreadInRoom(room, user, LAST_READ_MESSAGE_ID) } returns UNREAD_COUNT
+        every { messageRepository.findById(LAST_READ_MESSAGE_ID) } returns Optional.empty()
+
+        // when
+        val result = roomInfoMapper.map(userRoom)
+
+        // then
+        assertThat(result.lastMessage).isNull()
+        assertThat(result.roomId).isEqualTo(ROOM_ID)
+        assertThat(result.unreadCount).isEqualTo(UNREAD_COUNT)
+        assertThat(result.title).isEqualTo(TITLE)
+        assertThat(result.imageKey).isEqualTo(IMAGE_KEY)
+        assertThat(result.imageVersion).isEqualTo(IMAGE_VERSION)
+        assertThat(result.type).isEqualTo(ROOM_TYPE)
+        assertThat(result.memberCount).isEqualTo(MEMBER_COUNT)
+        assertThat(result.success).isEqualTo(SUCCESS)
+    }
+
+    private fun mockRoom(): Room = mockk<Room> {
+        every { id } returns ROOM_ID
+        every { title } returns TITLE
+        every { imageKey } returns IMAGE_KEY
+        every { imageVersion } returns IMAGE_VERSION
+        every { type } returns ROOM_TYPE
+        every { memberCount } returns MEMBER_COUNT
+        every { success } returns SUCCESS
+    }
+}

--- a/src/test/kotlin/goodspace/teaming/chat/domain/mapper/RoomMapperTest.kt
+++ b/src/test/kotlin/goodspace/teaming/chat/domain/mapper/RoomMapperTest.kt
@@ -1,0 +1,73 @@
+package goodspace.teaming.chat.domain.mapper
+
+import goodspace.teaming.chat.dto.RoomCreateRequestDto
+import goodspace.teaming.global.entity.room.Room
+import goodspace.teaming.global.entity.room.RoomType
+import org.assertj.core.api.Assertions.assertThat
+import kotlin.test.Test
+
+private const val TITLE = "default title"
+private const val MEMBER_COUNT = 10
+private val ROOM_TYPE = RoomType.BASIC
+private const val IMAGE_KEY = "images/123.png"
+private const val IMAGE_VERSION = 10
+
+class RoomMapperTest {
+    private val roomMapper = RoomMapper()
+
+    @Test
+    fun `모든 매핑 가능한 필드를 정확히 복사한다`() {
+        // given
+        val dto = createDto(
+            title = TITLE,
+            memberCount = MEMBER_COUNT,
+            roomType = ROOM_TYPE,
+            imageKey = IMAGE_KEY,
+            imageVersion = IMAGE_VERSION
+        )
+
+        // when
+        val room: Room = roomMapper.map(dto)
+
+        // then
+        assertThat(room.title).isEqualTo(dto.title)
+        assertThat(room.type).isEqualTo(dto.roomType)
+        assertThat(room.memberCount).isEqualTo(dto.memberCount)
+        assertThat(room.imageKey).isEqualTo(dto.imageKey)
+        assertThat(room.imageVersion).isEqualTo(dto.imageVersion)
+    }
+
+    @Test
+    fun `옵셔널한 속성은 null 값을 허용한다`() {
+        // given
+        val dto = createDto(
+            imageKey = null,
+            imageVersion = null
+        )
+
+        // when
+        val room = roomMapper.map(dto)
+
+        // then
+        assertThat(room.imageKey).isNull()
+        assertThat(room.imageVersion).isNull()
+    }
+
+    private fun createDto(
+        title: String = "기본 타이틀",
+        description: String = "기본 설명",
+        memberCount: Int = 10,
+        roomType: RoomType = RoomType.BASIC,
+        imageKey: String? = "default/key",
+        imageVersion: Int? = 1
+    ): RoomCreateRequestDto {
+        return RoomCreateRequestDto(
+            title = title,
+            description = description,
+            memberCount = memberCount,
+            roomType = roomType,
+            imageKey = imageKey,
+            imageVersion = imageVersion
+        )
+    }
+}

--- a/src/test/kotlin/goodspace/teaming/chat/service/RoomServiceTest.kt
+++ b/src/test/kotlin/goodspace/teaming/chat/service/RoomServiceTest.kt
@@ -1,0 +1,372 @@
+package goodspace.teaming.chat.service
+
+import goodspace.teaming.chat.domain.InviteCodeGenerator
+import goodspace.teaming.chat.domain.mapper.RoomInfoMapper
+import goodspace.teaming.chat.domain.mapper.RoomMapper
+import goodspace.teaming.chat.dto.InviteAcceptRequestDto
+import goodspace.teaming.chat.dto.RoomCreateRequestDto
+import goodspace.teaming.chat.dto.RoomInfoResponseDto
+import goodspace.teaming.chat.exception.InviteCodeAllocationFailedException
+import goodspace.teaming.global.entity.room.*
+import goodspace.teaming.global.entity.user.User
+import goodspace.teaming.global.repository.RoomRepository
+import goodspace.teaming.global.repository.UserRepository
+import goodspace.teaming.global.repository.UserRoomRepository
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.util.*
+
+private const val TITLE = "티밍룸 제목"
+private const val DESCRIPTION = "티밍룸 설명"
+private val ROOM_TYPE = RoomType.BASIC
+private const val MEMBER_COUNT = 5
+private const val USER_ID = 1L
+private const val ROOM_ID = 10L
+private const val INVITE_CODE = "ABC123"
+private const val DUPLICATE_CODE = "DUPLICATE"
+private const val UNIQUE_CODE = "UNIQUE"
+
+class RoomServiceTest {
+    private val userRepository: UserRepository = mockk()
+    private val roomRepository: RoomRepository = mockk()
+    private val userRoomRepository: UserRoomRepository = mockk()
+    private val roomMapper: RoomMapper = mockk()
+    private val roomInfoMapper: RoomInfoMapper = mockk(relaxed = true)
+    private val inviteCodeGenerator: InviteCodeGenerator = mockk()
+
+    private val roomService = RoomServiceImpl(
+        userRepository = userRepository,
+        roomRepository = roomRepository,
+        userRoomRepository = userRoomRepository,
+        roomMapper = roomMapper,
+        roomInfoMapper = roomInfoMapper,
+        inviteCodeGenerator = inviteCodeGenerator
+    )
+
+    @BeforeEach
+    fun setup() {
+        clearAllMocks()
+    }
+
+    @Nested
+    @DisplayName("createRoom")
+    inner class CreateRoom {
+        @Test
+        fun `팀장이 되어 새로운 티밍룸을 생성한다`() {
+            // given
+            val leader = mockk<User>(relaxed = true)
+            every { userRepository.findById(USER_ID) } returns Optional.of(leader)
+
+            val room = Room(title = TITLE, type = ROOM_TYPE, memberCount = MEMBER_COUNT)
+            every { roomMapper.map(any()) } returns room
+
+            every { inviteCodeGenerator.generate() } returns UNIQUE_CODE
+            every { roomRepository.existsByInviteCode(UNIQUE_CODE) } returns false
+            every { roomRepository.saveAndFlush(room) } returns room
+
+            // when
+            roomService.createRoom(USER_ID, getRoomCreateDto())
+
+            // then
+            assertThat(room.inviteCode).isEqualTo(UNIQUE_CODE)
+            assertThat(room.userRooms).hasSize(1)
+
+            val leaderUserRoom = room.userRooms.first()
+            assertThat(leaderUserRoom.roomRole).isEqualTo(RoomRole.LEADER)
+            assertThat(leaderUserRoom.user).isSameAs(leader)
+            assertThat(leaderUserRoom.room).isSameAs(room)
+        }
+
+        @Test
+        fun `중복되지 않는 초대코드를 설정한다`() {
+            // given
+            val user = mockk<User>(relaxed = true)
+            every { userRepository.findById(USER_ID) } returns Optional.of(user)
+
+            val room = Room(title = "제목", type = RoomType.BASIC, memberCount = 5)
+            every { roomMapper.map(any()) } returns room
+
+            // 두 번까지는 중복된 초대코드를 발행하도록 설정
+            every { inviteCodeGenerator.generate() } returnsMany listOf(DUPLICATE_CODE, DUPLICATE_CODE, UNIQUE_CODE)
+            every { roomRepository.existsByInviteCode(DUPLICATE_CODE) } returns true
+            every { roomRepository.existsByInviteCode(UNIQUE_CODE) } returns false
+            every { roomRepository.saveAndFlush(room) } returns room
+
+            // when
+            roomService.createRoom(USER_ID, getRoomCreateDto())
+
+            // then
+            assertThat(room.inviteCode).isEqualTo(UNIQUE_CODE)
+        }
+
+        @Test
+        fun `계속해서 중복되지 않은 초대코드 발행에 실패하면 예외를 던진다`() {
+            // given
+            val user = mockk<User>(relaxed = true)
+            every { userRepository.findById(USER_ID) } returns Optional.of(user)
+
+            val room = Room(title = "제목", type = RoomType.BASIC, memberCount = 5)
+            every { roomMapper.map(any()) } returns room
+
+            every { inviteCodeGenerator.generate() } returns DUPLICATE_CODE
+            every { roomRepository.existsByInviteCode(DUPLICATE_CODE) } returns true
+
+            // when & then
+            assertThatThrownBy { roomService.createRoom(USER_ID, getRoomCreateDto()) }
+                .isInstanceOf(InviteCodeAllocationFailedException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("acceptInvite")
+    inner class AcceptInvite {
+        @Test
+        fun `초대를 수락하여 방의 멤버로 합류한다`() {
+            // given
+            val user = mockk<User>(relaxed = true)
+            val room = Room(title = TITLE, type = ROOM_TYPE, memberCount = MEMBER_COUNT).apply { inviteCode = INVITE_CODE }
+
+            every { userRepository.findById(USER_ID) } returns Optional.of(user)
+            every { roomRepository.findByInviteCode(INVITE_CODE) } returns room
+            every { userRoomRepository.existsByRoomAndUser(room, user) } returns false
+
+            // when
+            roomService.acceptInvite(USER_ID, InviteAcceptRequestDto(inviteCode = INVITE_CODE))
+
+            // then
+            assertThat(room.userRooms).hasSize(1)
+
+            val membership = room.userRooms.first()
+            assertThat(membership.roomRole).isEqualTo(RoomRole.MEMBER)
+            assertThat(membership.user).isSameAs(user)
+            assertThat(membership.room).isSameAs(room)
+        }
+
+        @Test
+        fun `존재하지 않는 초대코드면 예외를 던진다`() {
+            // given
+            val user = mockk<User>(relaxed = true)
+            every { userRepository.findById(USER_ID) } returns Optional.of(user)
+            every { roomRepository.findByInviteCode(INVITE_CODE) } returns null
+
+            // when & then
+            assertThatThrownBy { roomService.acceptInvite(USER_ID, InviteAcceptRequestDto(inviteCode = INVITE_CODE)) }
+                .isInstanceOf(IllegalArgumentException::class.java)
+        }
+
+        @Test
+        fun `이미 멤버인 사용자가 초대를 수락하면 예외를 던진다`() {
+            // given: 이미 멤버인 상황
+            val user = mockk<User>(relaxed = true)
+            val room = Room(title = TITLE, type = ROOM_TYPE, memberCount = MEMBER_COUNT)
+                .apply { inviteCode = INVITE_CODE }
+
+            every { userRepository.findById(USER_ID) } returns Optional.of(user)
+            every { roomRepository.findByInviteCode(INVITE_CODE) } returns room
+            every { userRoomRepository.existsByRoomAndUser(room, user) } returns true
+            every { roomInfoMapper.map(any()) } returns mockk<RoomInfoResponseDto>(relaxed = true)
+
+            // when & then
+            assertThatThrownBy { roomService.acceptInvite(USER_ID, InviteAcceptRequestDto(inviteCode = INVITE_CODE)) }
+                .isInstanceOf(IllegalArgumentException::class.java)
+        }
+
+        @Test
+        fun `초대 수락에 성공하면 해당 티밍룸에 대한 DTO를 반환한다`() {
+            // given
+            val user = mockk<User>(relaxed = true)
+            val room = Room(title = "제목", type = RoomType.BASIC, memberCount = 5).apply { inviteCode = INVITE_CODE }
+            val roomDto = mockk<RoomInfoResponseDto>(relaxed = true)
+
+            every { userRepository.findById(USER_ID) } returns Optional.of(user)
+            every { roomRepository.findByInviteCode(INVITE_CODE) } returns room
+            every { userRoomRepository.existsByRoomAndUser(room, user) } returns false
+            every { roomInfoMapper.map(any()) } returns roomDto
+
+            // when
+            val result = roomService.acceptInvite(USER_ID, InviteAcceptRequestDto(inviteCode = INVITE_CODE))
+
+            // then
+            assertThat(result).isSameAs(roomDto)
+        }
+    }
+
+    @Nested
+    @DisplayName("getRooms")
+    inner class GetRooms {
+        @Test
+        fun `회원의 UserRoom들을 매핑하여 반환한다`() {
+            // given
+            val user = mockk<User>()
+            val ur1 = mockk<UserRoom>()
+            val ur2 = mockk<UserRoom>()
+            val dto1 = mockk<RoomInfoResponseDto>()
+            val dto2 = mockk<RoomInfoResponseDto>()
+
+            every { userRepository.findById(USER_ID) } returns Optional.of(user)
+            every { user.userRooms } returns mutableListOf(ur1, ur2)
+            every { roomInfoMapper.map(ur1) } returns dto1
+            every { roomInfoMapper.map(ur2) } returns dto2
+
+            // when
+            val result = roomService.getRooms(USER_ID)
+
+            // then
+            assertThat(result).containsExactly(dto1, dto2)
+        }
+
+        @Test
+        fun `티밍룸이 없으면 빈 리스트를 반환한다`() {
+            // given
+            val user = mockk<User>()
+            every { userRepository.findById(USER_ID) } returns Optional.of(user)
+            every { user.userRooms } returns mutableListOf()
+
+            // when
+            val result = roomService.getRooms(USER_ID)
+
+            // then
+            assertThat(result).isEmpty()
+        }
+    }
+
+    @Nested
+    @DisplayName("leaveRoom")
+    inner class LeaveRoom {
+        @Test
+        fun `방을 떠난다`() {
+            // given: user와 anotherUesr가 room에 소속되어 있는 상태
+            val room = Room(title = TITLE, type = ROOM_TYPE, memberCount = MEMBER_COUNT)
+            val user = mockk<User>(relaxed = true)
+            val userRoom = UserRoom(user = user, room = room, roomRole = RoomRole.MEMBER).apply {
+                paymentStatus = PaymentStatus.PAID
+            }
+            room.addUserRoom(userRoom)
+            every { userRoomRepository.findByRoomIdAndUserId(ROOM_ID, USER_ID) } returns userRoom
+
+            val anotherUser = mockk<User>(relaxed = true)
+            val anotherUserRoom = UserRoom(user = anotherUser, room = room, roomRole = RoomRole.MEMBER).apply {
+                paymentStatus = PaymentStatus.PAID
+            }
+            room.addUserRoom(anotherUserRoom)
+
+            // when
+            roomService.leaveRoom(USER_ID, ROOM_ID)
+
+            // then
+            assertThat(room.userRooms).doesNotContain(userRoom)
+        }
+
+        @Test
+        fun `마지막 멤버가 떠나면 방을 삭제한다`() {
+            // given: 방에 멤버 1명뿐인 상태
+            val room = Room(
+                title = TITLE, type = ROOM_TYPE, memberCount = MEMBER_COUNT
+            )
+            val user = mockk<User>(relaxed = true)
+            val userRoom = UserRoom(user = user, room = room, roomRole = RoomRole.MEMBER).apply {
+                paymentStatus = PaymentStatus.PAID
+            }
+            room.addUserRoom(userRoom)
+
+            every { userRoomRepository.findByRoomIdAndUserId(ROOM_ID, USER_ID) } returns userRoom
+            every { roomRepository.delete(room) } returns Unit
+
+            // when
+            roomService.leaveRoom(USER_ID, ROOM_ID)
+
+            // then
+            assertThat(room.userRooms).isEmpty()
+            verify(exactly = 1) { roomRepository.delete(room) }
+        }
+
+        @Test
+        fun `티밍룸을 찾지 못하면 예외를 던진다`() {
+            // given
+            every { userRoomRepository.findByRoomIdAndUserId(ROOM_ID, USER_ID) } returns null
+
+            // when & then
+            assertThatThrownBy { roomService.leaveRoom(USER_ID, ROOM_ID) }
+                .isInstanceOf(IllegalArgumentException::class.java)
+        }
+
+        @Test
+        fun `결제가 되어 있지 않으면 예외를 던진다`() {
+            // given
+            val room = mockk<Room>(relaxed = true)
+            val userRoom = mockk<UserRoom> {
+                every { this@mockk.room } returns room
+                every { paymentStatus } returns PaymentStatus.NOT_PAID
+            }
+            every { userRoomRepository.findByRoomIdAndUserId(ROOM_ID, USER_ID) } returns userRoom
+
+            // when & then
+            assertThatThrownBy { roomService.leaveRoom(USER_ID, ROOM_ID) }
+                .isInstanceOf(IllegalArgumentException::class.java)
+        }
+    }
+
+    @Nested
+    @DisplayName("setSuccess")
+    inner class SetSuccess {
+        @Test
+        fun `티밍룸의 상태를 '팀플 성공'으로 만든다`() {
+            // given
+            val room = Room(title = TITLE, type = ROOM_TYPE, memberCount = MEMBER_COUNT).apply { success = false }
+            val user = mockk<User>(relaxed = true)
+            val userRoom = UserRoom(user = user, room = room, roomRole = RoomRole.LEADER)
+
+            every { userRoomRepository.findByRoomIdAndUserId(ROOM_ID, USER_ID) } returns userRoom
+
+            // when
+            roomService.setSuccess(USER_ID, ROOM_ID)
+
+            // then
+            assertThat(room.success).isTrue()
+        }
+
+        @Test
+        fun `방을 찾지 못하면 예외를 던진다`() {
+            every { userRoomRepository.findByRoomIdAndUserId(ROOM_ID, USER_ID) } returns null
+
+            assertThatThrownBy { roomService.setSuccess(USER_ID, ROOM_ID) }
+                .isInstanceOf(IllegalArgumentException::class.java)
+        }
+
+        @Test
+        fun `팀장이 아니면 예외를 던진다`() {
+            // given
+            val room = Room(title = TITLE, type = ROOM_TYPE, memberCount = MEMBER_COUNT).apply { success = false }
+            val user = mockk<User>(relaxed = true)
+            val userRoom = UserRoom(user = user, room = room, roomRole = RoomRole.MEMBER)
+
+            every { userRoomRepository.findByRoomIdAndUserId(ROOM_ID, USER_ID) } returns userRoom
+
+            // when & then
+            assertThatThrownBy { roomService.setSuccess(USER_ID, ROOM_ID) }
+                .isInstanceOf(IllegalStateException::class.java)
+        }
+
+        @Test
+        fun `환불 이벤트를 발생시킨다`() {
+            //TODO: 결제 로직 우선 구현 필요
+        }
+    }
+
+    private fun getRoomCreateDto() = RoomCreateRequestDto(
+        title = TITLE,
+        description = DESCRIPTION,
+        memberCount = MEMBER_COUNT,
+        roomType = ROOM_TYPE,
+        imageKey = null,
+        imageVersion = null
+    )
+}

--- a/src/test/kotlin/goodspace/teaming/fixture/RoomFixture.kt
+++ b/src/test/kotlin/goodspace/teaming/fixture/RoomFixture.kt
@@ -29,11 +29,12 @@ enum class RoomFixture(
         "elite invite"
     );
 
-    fun getInstance(): Room {
+    fun getInstance(memberCount: Int = 5): Room {
         return Room(
             title = title,
             type = type,
-            inviteCode = inviteCode
+            inviteCode = inviteCode,
+            memberCount = memberCount
         )
     }
 }


### PR DESCRIPTION
## 🔍 개요
<!--
  무엇을 변경했나요?
  왜 변경했나요? (이유/동기/관련 테켓)
-->
티밍룸 API를 구현했습니다.
기존의 채팅 API 로직을 개선했습니다.
`ChatService`를 `MessageService`로 개명했습니다.

## 🔗 관련 이슈
<!--
  이슈 번호 및 링크
-->
#1 
#15 

## 📝 참고할 사항
환불 이벤트와 벌칙 이벤트를 구현하지 않았습니다.
이후에 결제 API 구현 후 마무리할 예정입니다.