### PR TITLE
[feat/#21] 과제 API 구현

### DIFF
--- a/src/main/kotlin/goodspace/teaming/assignment/controller/AssignmentController.kt
+++ b/src/main/kotlin/goodspace/teaming/assignment/controller/AssignmentController.kt
@@ -1,0 +1,78 @@
+package goodspace.teaming.assignment.controller
+
+import goodspace.teaming.assignment.dto.SubmissionRequestDto
+import goodspace.teaming.assignment.dto.AssignmentCreateRequestDto
+import goodspace.teaming.assignment.dto.AssignmentResponseDto
+import goodspace.teaming.assignment.service.AssignmentService
+import goodspace.teaming.global.security.getUserId
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+import java.security.Principal
+
+private val NO_CONTENT = ResponseEntity.noContent().build<Void>()
+
+@RestController
+@RequestMapping("/rooms/{roomId}/assignment")
+@Tag(
+    name = "과제 API"
+)
+class AssignmentController(
+    private val assignmentService: AssignmentService
+) {
+    @GetMapping
+    @Operation(
+        summary = "과제 조회",
+        description = "해당 방의 모든 과제를 조회합니다."
+    )
+    fun getAssignments(
+        principal: Principal,
+        @PathVariable roomId: Long
+    ): ResponseEntity<List<AssignmentResponseDto>> {
+        val userId = principal.getUserId()
+
+        val response = assignmentService.get(userId, roomId)
+
+        return ResponseEntity.ok(response)
+    }
+
+    @PostMapping
+    @Operation(
+        summary = "과제 생성",
+        description = "새로운 과제를 생성합니다."
+    )
+    fun createAssignment(
+        principal: Principal,
+        @PathVariable roomId: Long,
+        @RequestBody requestDto: AssignmentCreateRequestDto
+    ): ResponseEntity<Void> {
+        val userId = principal.getUserId()
+
+        assignmentService.create(userId, roomId, requestDto)
+
+        return NO_CONTENT
+    }
+
+    @PostMapping("/submit")
+    @Operation(
+        summary = "과제 제출",
+        description = "과제를 제출합니다. 과제가 완수됩니다."
+    )
+    fun completeAssignment(
+        principal: Principal,
+        @PathVariable roomId: Long,
+        @RequestBody requestDto: SubmissionRequestDto
+    ): ResponseEntity<Void> {
+        val userId = principal.getUserId()
+
+        assignmentService.submit(userId, roomId, requestDto)
+
+        return NO_CONTENT
+    }
+}

--- a/src/main/kotlin/goodspace/teaming/assignment/domain/mapper/AssignedMemberMapper.kt
+++ b/src/main/kotlin/goodspace/teaming/assignment/domain/mapper/AssignedMemberMapper.kt
@@ -1,0 +1,28 @@
+package goodspace.teaming.assignment.domain.mapper
+
+import goodspace.teaming.global.entity.aissgnment.AssignedMember
+import goodspace.teaming.global.entity.aissgnment.Assignment
+import goodspace.teaming.global.entity.room.Room
+import goodspace.teaming.global.entity.user.User
+import org.springframework.stereotype.Component
+
+private const val NOT_MEMBER = "해당 티밍룸에 소속되어 있지 않습니다."
+
+@Component
+class AssignedMemberMapper {
+    fun map(user: User, room: Room, assignment: Assignment): AssignedMember {
+        val memberSet = room.memberSet()
+        require(memberSet.contains(user)) { NOT_MEMBER }
+
+        return AssignedMember(
+            user = user,
+            assignment = assignment
+        )
+    }
+
+    private fun Room.memberSet(): Set<User> {
+        return this.userRooms
+            .map { it.user }
+            .toSet()
+    }
+}

--- a/src/main/kotlin/goodspace/teaming/assignment/domain/mapper/AssignmentMapper.kt
+++ b/src/main/kotlin/goodspace/teaming/assignment/domain/mapper/AssignmentMapper.kt
@@ -1,0 +1,41 @@
+package goodspace.teaming.assignment.domain.mapper
+
+import goodspace.teaming.assignment.dto.AssignmentCreateRequestDto
+import goodspace.teaming.assignment.dto.AssignmentResponseDto
+import goodspace.teaming.assignment.dto.SubmissionResponseDto
+import goodspace.teaming.global.entity.aissgnment.Assignment
+import goodspace.teaming.global.entity.aissgnment.AssignmentStatus.IN_PROGRESS
+import goodspace.teaming.global.entity.aissgnment.Submission
+import goodspace.teaming.global.entity.room.Room
+import org.springframework.stereotype.Component
+
+@Component
+class AssignmentMapper(
+    private val submissionMapper: SubmissionMapper
+) {
+    fun map(room: Room, dto: AssignmentCreateRequestDto): Assignment {
+        return Assignment(
+            title = dto.title,
+            description = dto.description,
+            room = room,
+            due = dto.due,
+            status = IN_PROGRESS
+        )
+    }
+
+    fun map(assignment: Assignment): AssignmentResponseDto {
+        return AssignmentResponseDto(
+            assignmentId = assignment.id!!,
+            title = assignment.title,
+            description = assignment.description,
+            assignedMemberIds = assignment.assignedMemberIds,
+            due = assignment.due,
+            status = assignment.status,
+            submissions = assignment.submissions.toDto()
+        )
+    }
+
+    private fun List<Submission>.toDto(): List<SubmissionResponseDto> {
+        return this.map { submissionMapper.map(it) }
+    }
+}

--- a/src/main/kotlin/goodspace/teaming/assignment/domain/mapper/SubmissionMapper.kt
+++ b/src/main/kotlin/goodspace/teaming/assignment/domain/mapper/SubmissionMapper.kt
@@ -1,0 +1,26 @@
+package goodspace.teaming.assignment.domain.mapper
+
+import goodspace.teaming.assignment.dto.SubmissionResponseDto
+import goodspace.teaming.assignment.dto.SubmittedFileResponseDto
+import goodspace.teaming.global.entity.aissgnment.Submission
+import goodspace.teaming.global.entity.file.File
+import org.springframework.stereotype.Component
+
+@Component
+class SubmissionMapper(
+    private val submittedFileMapper: SubmittedFileMapper
+) {
+    fun map(submission: Submission): SubmissionResponseDto {
+        return SubmissionResponseDto(
+            submitterId = submission.submitterId,
+            description = submission.description,
+            createdAt = submission.createdAt!!,
+            updatedAt = submission.updatedAt,
+            files = submission.files.toDto()
+        )
+    }
+
+    private fun List<File>.toDto(): List<SubmittedFileResponseDto> {
+        return this.map { submittedFileMapper.map(it) }
+    }
+}

--- a/src/main/kotlin/goodspace/teaming/assignment/domain/mapper/SubmittedFileMapper.kt
+++ b/src/main/kotlin/goodspace/teaming/assignment/domain/mapper/SubmittedFileMapper.kt
@@ -1,0 +1,18 @@
+package goodspace.teaming.assignment.domain.mapper
+
+import goodspace.teaming.assignment.dto.SubmittedFileResponseDto
+import goodspace.teaming.global.entity.file.File
+import org.springframework.stereotype.Component
+
+@Component
+class SubmittedFileMapper {
+    fun map(file: File): SubmittedFileResponseDto {
+        return SubmittedFileResponseDto(
+            fileId = file.id!!,
+            fileName = file.name,
+            fileType = file.type,
+            mimeType = file.mimeType,
+            fileSize = file.byteSize
+        )
+    }
+}

--- a/src/main/kotlin/goodspace/teaming/assignment/dto/AssignmentCreateRequestDto.kt
+++ b/src/main/kotlin/goodspace/teaming/assignment/dto/AssignmentCreateRequestDto.kt
@@ -1,0 +1,10 @@
+package goodspace.teaming.assignment.dto
+
+import java.time.Instant
+
+data class AssignmentCreateRequestDto(
+    val title: String,
+    val description: String,
+    val assignedMemberIds: List<Long>,
+    val due: Instant
+)

--- a/src/main/kotlin/goodspace/teaming/assignment/dto/AssignmentResponseDto.kt
+++ b/src/main/kotlin/goodspace/teaming/assignment/dto/AssignmentResponseDto.kt
@@ -1,0 +1,14 @@
+package goodspace.teaming.assignment.dto
+
+import goodspace.teaming.global.entity.aissgnment.AssignmentStatus
+import java.time.Instant
+
+data class AssignmentResponseDto(
+    val assignmentId: Long,
+    val title: String,
+    val description: String,
+    val assignedMemberIds: List<Long>,
+    val due: Instant,
+    val status: AssignmentStatus,
+    val submissions: List<SubmissionResponseDto>
+)

--- a/src/main/kotlin/goodspace/teaming/assignment/dto/SubmissionRequestDto.kt
+++ b/src/main/kotlin/goodspace/teaming/assignment/dto/SubmissionRequestDto.kt
@@ -1,0 +1,7 @@
+package goodspace.teaming.assignment.dto
+
+data class SubmissionRequestDto(
+    val assignmentId: Long,
+    val description: String,
+    val fileIds: List<Long>
+)

--- a/src/main/kotlin/goodspace/teaming/assignment/dto/SubmissionResponseDto.kt
+++ b/src/main/kotlin/goodspace/teaming/assignment/dto/SubmissionResponseDto.kt
@@ -1,0 +1,11 @@
+package goodspace.teaming.assignment.dto
+
+import java.time.Instant
+
+data class SubmissionResponseDto(
+    val submitterId: Long,
+    val description: String,
+    val createdAt: Instant,
+    val updatedAt: Instant?,
+    val files: List<SubmittedFileResponseDto>
+)

--- a/src/main/kotlin/goodspace/teaming/assignment/dto/SubmittedFileResponseDto.kt
+++ b/src/main/kotlin/goodspace/teaming/assignment/dto/SubmittedFileResponseDto.kt
@@ -1,0 +1,11 @@
+package goodspace.teaming.assignment.dto
+
+import goodspace.teaming.global.entity.file.FileType
+
+data class SubmittedFileResponseDto(
+    val fileId: Long,
+    val fileName: String,
+    val fileType: FileType,
+    val mimeType: String,
+    val fileSize: Long,
+)

--- a/src/main/kotlin/goodspace/teaming/assignment/service/AssignmentService.kt
+++ b/src/main/kotlin/goodspace/teaming/assignment/service/AssignmentService.kt
@@ -1,0 +1,24 @@
+package goodspace.teaming.assignment.service
+
+import goodspace.teaming.assignment.dto.SubmissionRequestDto
+import goodspace.teaming.assignment.dto.AssignmentCreateRequestDto
+import goodspace.teaming.assignment.dto.AssignmentResponseDto
+
+interface AssignmentService {
+    fun create(
+        userId: Long,
+        roomId: Long,
+        requestDto: AssignmentCreateRequestDto
+    )
+
+    fun get(
+        userId: Long,
+        roomId: Long
+    ): List<AssignmentResponseDto>
+
+    fun submit(
+        userId: Long,
+        roomId: Long,
+        requestDto: SubmissionRequestDto
+    )
+}

--- a/src/main/kotlin/goodspace/teaming/assignment/service/AssignmentServiceImpl.kt
+++ b/src/main/kotlin/goodspace/teaming/assignment/service/AssignmentServiceImpl.kt
@@ -1,0 +1,101 @@
+package goodspace.teaming.assignment.service
+
+import goodspace.teaming.assignment.domain.mapper.AssignedMemberMapper
+import goodspace.teaming.assignment.domain.mapper.AssignmentMapper
+import goodspace.teaming.assignment.dto.AssignmentCreateRequestDto
+import goodspace.teaming.assignment.dto.AssignmentResponseDto
+import goodspace.teaming.assignment.dto.SubmissionRequestDto
+import goodspace.teaming.global.entity.aissgnment.Assignment
+import goodspace.teaming.global.entity.aissgnment.AssignmentStatus.COMPLETE
+import goodspace.teaming.global.entity.aissgnment.Submission
+import goodspace.teaming.global.entity.room.PaymentStatus.NOT_PAID
+import goodspace.teaming.global.entity.room.UserRoom
+import goodspace.teaming.global.entity.user.User
+import goodspace.teaming.global.repository.FileRepository
+import goodspace.teaming.global.repository.UserRepository
+import goodspace.teaming.global.repository.UserRoomRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+private const val USER_ROOM_NOT_FOUND = "해당 티밍룸에 소속되어있지 않습니다."
+private const val INACCESSIBLE = "해당 티밍룸에 접근할 수 없습니다."
+private const val MEMBER_FOR_ASSIGNED_NOT_FOUND = "과제를 할당할 회원을 조회할 수 없습니다."
+private const val FILE_NOT_FOUND = "파일을 찾을 수 없습니다."
+
+@Service
+class AssignmentServiceImpl(
+    private val userRoomRepository: UserRoomRepository,
+    private val userRepository: UserRepository,
+    private val assignmentMapper: AssignmentMapper,
+    private val assignedMemberMapper: AssignedMemberMapper,
+    private val fileRepository: FileRepository
+) : AssignmentService {
+    @Transactional
+    override fun create(userId: Long, roomId: Long, requestDto: AssignmentCreateRequestDto) {
+        val userRoom = findUserRoom(userId, roomId)
+        val room = userRoom.room
+
+        assertPayment(userRoom)
+
+        val assignment = assignmentMapper.map(room, requestDto)
+        val assignedMembers = requestDto.assignedMemberIds
+            .toUserSet()
+            .map { assignedMemberMapper.map(it, room, assignment) }
+
+        assignment.addAssignedMembers(assignedMembers)
+    }
+
+    @Transactional(readOnly = true)
+    override fun get(userId: Long, roomId: Long): List<AssignmentResponseDto> {
+        val userRoom = findUserRoom(userId, roomId)
+        val room = userRoom.room
+
+        assertPayment(userRoom)
+
+        return room.assignments
+            .map { assignmentMapper.map(it) }
+    }
+
+    @Transactional
+    override fun submit(userId: Long, roomId: Long, requestDto: SubmissionRequestDto) {
+        val userRoom = findUserRoom(userId, roomId)
+        val room = userRoom.room
+
+        assertPayment(userRoom)
+
+        val files = fileRepository.findAllById(requestDto.fileIds)
+        require(files.size == requestDto.fileIds.size) { FILE_NOT_FOUND }
+
+        val assignment = room.assignments.findById(requestDto.assignmentId)
+        val submission = Submission(
+            assignment = assignment,
+            files = files,
+            submitterId = userId,
+            description = requestDto.description
+        )
+
+        assignment.addSubmission(submission)
+        assignment.status = COMPLETE
+    }
+
+    private fun findUserRoom(userId: Long, roomId: Long): UserRoom {
+        return userRoomRepository.findByRoomIdAndUserId(roomId, userId)
+            ?: throw IllegalArgumentException(USER_ROOM_NOT_FOUND)
+    }
+
+    private fun assertPayment(userRoom: UserRoom) {
+        require(userRoom.paymentStatus != NOT_PAID) { INACCESSIBLE }
+    }
+
+    private fun List<Long>.toUserSet(): Set<User> {
+        return this.map {
+            userRepository.findById(it)
+                .orElseThrow { IllegalArgumentException(MEMBER_FOR_ASSIGNED_NOT_FOUND) }
+        }.toSet()
+    }
+
+    private fun List<Assignment>.findById(id: Long): Assignment {
+        return this.firstOrNull { it.id == id }
+            ?: throw IllegalArgumentException(FILE_NOT_FOUND)
+    }
+}

--- a/src/main/kotlin/goodspace/teaming/chat/dto/ChatMessageResponseDto.kt
+++ b/src/main/kotlin/goodspace/teaming/chat/dto/ChatMessageResponseDto.kt
@@ -1,7 +1,7 @@
 package goodspace.teaming.chat.dto
 
 import goodspace.teaming.global.entity.room.MessageType
-import java.time.LocalDateTime
+import java.time.Instant
 
 data class ChatMessageResponseDto(
     val messageId: Long,
@@ -9,7 +9,7 @@ data class ChatMessageResponseDto(
     val clientMessageId: String,
     val type: MessageType,
     val content: String?,
-    val createdAt: LocalDateTime,
+    val createdAt: Instant,
     val sender: SenderSummaryResponseDto,
     val attachments: List<MessageAttachmentResponseDto> = emptyList()
 )

--- a/src/main/kotlin/goodspace/teaming/global/entity/BaseEntity.kt
+++ b/src/main/kotlin/goodspace/teaming/global/entity/BaseEntity.kt
@@ -10,6 +10,7 @@ import lombok.experimental.SuperBuilder
 import org.springframework.data.annotation.CreatedDate
 import org.springframework.data.annotation.LastModifiedDate
 import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.Instant
 import java.time.LocalDateTime
 
 @MappedSuperclass
@@ -20,11 +21,11 @@ import java.time.LocalDateTime
 class BaseEntity(
     @CreatedDate
     @Column(updatable = false, nullable = false)
-    var createdAt: LocalDateTime? = null,
+    var createdAt: Instant? = null,
 
     @LastModifiedDate
     @Column(nullable = false)
-    var updatedAt: LocalDateTime? = null,
+    var updatedAt: Instant? = null,
 
     @Column(nullable = false)
     var deleted: Boolean = false,

--- a/src/main/kotlin/goodspace/teaming/global/entity/aissgnment/AssignedMember.kt
+++ b/src/main/kotlin/goodspace/teaming/global/entity/aissgnment/AssignedMember.kt
@@ -1,0 +1,27 @@
+package goodspace.teaming.global.entity.aissgnment
+
+import goodspace.teaming.global.entity.BaseEntity
+import goodspace.teaming.global.entity.user.User
+import jakarta.persistence.*
+import jakarta.persistence.FetchType.*
+import jakarta.persistence.GenerationType.IDENTITY
+import org.hibernate.annotations.SQLDelete
+import org.hibernate.annotations.SQLRestriction
+
+@Entity
+@Inheritance(strategy = InheritanceType.JOINED)
+@SQLDelete(sql = "UPDATE `assigned_member` SET deleted = true, deleted_at = NOW() WHERE id = ?")
+@SQLRestriction("deleted = false")
+class AssignedMember(
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(nullable = false)
+    val user: User,
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(nullable = false)
+    val assignment: Assignment,
+) : BaseEntity() {
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    val id: Long? = null
+}

--- a/src/main/kotlin/goodspace/teaming/global/entity/aissgnment/Assignment.kt
+++ b/src/main/kotlin/goodspace/teaming/global/entity/aissgnment/Assignment.kt
@@ -1,0 +1,57 @@
+package goodspace.teaming.global.entity.aissgnment
+
+import goodspace.teaming.global.entity.BaseEntity
+import goodspace.teaming.global.entity.aissgnment.AssignmentStatus.IN_PROGRESS
+import goodspace.teaming.global.entity.room.Room
+import jakarta.persistence.*
+import jakarta.persistence.CascadeType.ALL
+import jakarta.persistence.EnumType.STRING
+import jakarta.persistence.FetchType.LAZY
+import jakarta.persistence.GenerationType.IDENTITY
+import org.hibernate.annotations.SQLDelete
+import org.hibernate.annotations.SQLRestriction
+import java.time.Instant
+
+@Entity
+@Inheritance(strategy = InheritanceType.JOINED)
+@SQLDelete(sql = "UPDATE `assignment` SET deleted = true, deleted_at = NOW() WHERE id = ?")
+@SQLRestriction("deleted = false")
+class Assignment(
+    @Column(nullable = false)
+    val title: String,
+
+    @Column(nullable = false)
+    val description: String,
+
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(nullable = false)
+    val room: Room,
+
+    @OneToMany(mappedBy = "assignment", fetch = LAZY, cascade = [ALL])
+    val submissions: MutableList<Submission> = mutableListOf(),
+
+    @Column(nullable = false)
+    val due: Instant,
+
+    @Column(nullable = false)
+    @Enumerated(STRING)
+    var status: AssignmentStatus = IN_PROGRESS,
+) : BaseEntity() {
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    val id: Long? = null
+
+    @OneToMany(mappedBy = "assignment", fetch = LAZY, cascade = [ALL])
+    private val assignedMembers: MutableList<AssignedMember> = mutableListOf()
+
+    val assignedMemberIds: List<Long>
+        get() = assignedMembers.map { it.user.id!! }
+
+    fun addAssignedMembers(assignedMembers: Collection<AssignedMember>) {
+        this.assignedMembers.addAll(assignedMembers)
+    }
+
+    fun addSubmission(submission: Submission) {
+        submissions.add(submission)
+    }
+}

--- a/src/main/kotlin/goodspace/teaming/global/entity/aissgnment/AssignmentStatus.kt
+++ b/src/main/kotlin/goodspace/teaming/global/entity/aissgnment/AssignmentStatus.kt
@@ -1,0 +1,5 @@
+package goodspace.teaming.global.entity.aissgnment
+
+enum class AssignmentStatus{
+    IN_PROGRESS, COMPLETE
+}

--- a/src/main/kotlin/goodspace/teaming/global/entity/aissgnment/Submission.kt
+++ b/src/main/kotlin/goodspace/teaming/global/entity/aissgnment/Submission.kt
@@ -1,0 +1,32 @@
+package goodspace.teaming.global.entity.aissgnment
+
+import goodspace.teaming.global.entity.BaseEntity
+import goodspace.teaming.global.entity.file.File
+import jakarta.persistence.*
+import jakarta.persistence.CascadeType.*
+import jakarta.persistence.FetchType.*
+import org.hibernate.annotations.SQLDelete
+import org.hibernate.annotations.SQLRestriction
+
+@Entity
+@Inheritance(strategy = InheritanceType.JOINED)
+@SQLDelete(sql = "UPDATE `submission` SET deleted = true, deleted_at = NOW() WHERE id = ?")
+@SQLRestriction("deleted = false")
+class Submission(
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(nullable = false)
+    val assignment: Assignment,
+
+    @OneToMany(fetch = LAZY, cascade = [ALL], orphanRemoval = true)
+    val files: MutableList<File> = mutableListOf(),
+
+    @Column(nullable = false)
+    val submitterId: Long,
+
+    @Column(nullable = false)
+    val description: String,
+) : BaseEntity() {
+    @Id
+    @GeneratedValue
+    val id: Long? = null
+}

--- a/src/main/kotlin/goodspace/teaming/global/entity/room/Room.kt
+++ b/src/main/kotlin/goodspace/teaming/global/entity/room/Room.kt
@@ -1,6 +1,7 @@
 package goodspace.teaming.global.entity.room
 
 import goodspace.teaming.global.entity.BaseEntity
+import goodspace.teaming.global.entity.aissgnment.Assignment
 import jakarta.persistence.*
 import jakarta.persistence.CascadeType.*
 import jakarta.persistence.EnumType.*
@@ -38,6 +39,9 @@ class Room(
 
     @OneToMany(fetch = LAZY, mappedBy = "room", cascade = [ALL], orphanRemoval = true)
     val userRooms: MutableList<UserRoom> = mutableListOf()
+
+    @OneToMany(fetch = LAZY, mappedBy = "room", cascade = [ALL], orphanRemoval = true)
+    val assignments: MutableList<Assignment> = mutableListOf()
 
     var success: Boolean = false
 

--- a/src/test/kotlin/goodspace/teaming/chat/domain/mapper/ChatMessageResponseMapperTest.kt
+++ b/src/test/kotlin/goodspace/teaming/chat/domain/mapper/ChatMessageResponseMapperTest.kt
@@ -21,14 +21,14 @@ import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.test.util.ReflectionTestUtils
-import java.time.LocalDateTime
+import java.time.Instant
 
 private const val DEFAULT_MESSAGE_ID = 1001L
 private const val DEFAULT_ROOM_ID = 2002L
 private const val DEFAULT_USER_ID = 3003L
 private const val DEFAULT_CLIENT_MESSAGE_ID = "client-123"
 private const val DEFAULT_CONTENT = "hello world"
-private val DEFAULT_CREATED_AT = LocalDateTime.now()
+private val DEFAULT_CREATED_AT = Instant.now()
 
 class ChatMessageResponseMapperTest {
     private val attachmentMapper = mockk<AttachmentMapper>()

--- a/src/test/kotlin/goodspace/teaming/chat/domain/mapper/LastMessagePreviewMapperTest.kt
+++ b/src/test/kotlin/goodspace/teaming/chat/domain/mapper/LastMessagePreviewMapperTest.kt
@@ -7,14 +7,14 @@ import org.assertj.core.api.Assertions.assertThat
 import org.assertj.core.api.Assertions.assertThatThrownBy
 import org.junit.jupiter.api.Test
 import org.springframework.test.util.ReflectionTestUtils
-import java.time.LocalDateTime
+import java.time.Instant
 import java.time.ZoneId
 
 private const val CONTENT = "hello world"
 private const val CLIENT_MESSAGE_ID = "clientMessageId"
 private const val ID = 6L
 private val TYPE = MessageType.TEXT
-private val CREATED_AT = LocalDateTime.now()
+private val CREATED_AT = Instant.now()
 
 class LastMessagePreviewMapperTest {
     private val senderSummaryMapper = mockk<SenderSummaryMapper>(relaxed = true)


### PR DESCRIPTION
## 🔍 개요
<!--
  무엇을 변경했나요?
  왜 변경했나요? (이유/동기/관련 테켓)
-->
과제 API를 구현했습니다.
`BaseEntity`의 시간 관련 속성 자료형을 `Instant`로 변경했습니다.

## 🔗 관련 이슈
<!--
  이슈 번호 및 링크
-->
#21 

## 📝 참고할 사항
시간 관계상 테스트 코드는 추후에 작성할 예정입니다.
