### PR TITLE
[chore/#21] 과제 관련 엔티티의 형식 변경

### DIFF
--- a/src/main/kotlin/goodspace/teaming/assignment/service/AssignmentServiceImpl.kt
+++ b/src/main/kotlin/goodspace/teaming/assignment/service/AssignmentServiceImpl.kt
@@ -8,6 +8,8 @@ import goodspace.teaming.assignment.dto.SubmissionRequestDto
 import goodspace.teaming.global.entity.aissgnment.Assignment
 import goodspace.teaming.global.entity.aissgnment.AssignmentStatus.COMPLETE
 import goodspace.teaming.global.entity.aissgnment.Submission
+import goodspace.teaming.global.entity.aissgnment.SubmittedFile
+import goodspace.teaming.global.entity.file.File
 import goodspace.teaming.global.entity.room.PaymentStatus.NOT_PAID
 import goodspace.teaming.global.entity.room.UserRoom
 import goodspace.teaming.global.entity.user.User
@@ -69,10 +71,11 @@ class AssignmentServiceImpl(
         val assignment = room.assignments.findById(requestDto.assignmentId)
         val submission = Submission(
             assignment = assignment,
-            files = files,
             submitterId = userId,
             description = requestDto.description
         )
+        val submittedFiles = files.toSubmittedFiles(submission)
+        submission.addSubmittedFiles(submittedFiles)
 
         assignment.addSubmission(submission)
         assignment.status = COMPLETE
@@ -97,5 +100,9 @@ class AssignmentServiceImpl(
     private fun List<Assignment>.findById(id: Long): Assignment {
         return this.firstOrNull { it.id == id }
             ?: throw IllegalArgumentException(FILE_NOT_FOUND)
+    }
+
+    private fun List<File>.toSubmittedFiles(submission: Submission): List<SubmittedFile> {
+        return this.map { SubmittedFile(submission, it) }
     }
 }

--- a/src/main/kotlin/goodspace/teaming/global/entity/aissgnment/Submission.kt
+++ b/src/main/kotlin/goodspace/teaming/global/entity/aissgnment/Submission.kt
@@ -1,7 +1,6 @@
 package goodspace.teaming.global.entity.aissgnment
 
 import goodspace.teaming.global.entity.BaseEntity
-import goodspace.teaming.global.entity.file.File
 import jakarta.persistence.*
 import jakarta.persistence.CascadeType.*
 import jakarta.persistence.FetchType.*
@@ -18,9 +17,6 @@ class Submission(
     @JoinColumn(nullable = false)
     val assignment: Assignment,
 
-    @OneToMany(fetch = LAZY, cascade = [ALL], orphanRemoval = true)
-    val files: MutableList<File> = mutableListOf(),
-
     @Column(nullable = false)
     val submitterId: Long,
 
@@ -30,4 +26,14 @@ class Submission(
     @Id
     @GeneratedValue(strategy = IDENTITY)
     val id: Long? = null
+
+    @OneToMany(mappedBy = "submission", fetch = LAZY, cascade = [ALL], orphanRemoval = true)
+    val submittedFiles: MutableList<SubmittedFile> = mutableListOf()
+
+    val files
+        get() = this.submittedFiles.map { it.file }
+
+    fun addSubmittedFiles(submittedFiles: List<SubmittedFile>) {
+        this.submittedFiles.addAll(submittedFiles)
+    }
 }

--- a/src/main/kotlin/goodspace/teaming/global/entity/aissgnment/SubmittedFile.kt
+++ b/src/main/kotlin/goodspace/teaming/global/entity/aissgnment/SubmittedFile.kt
@@ -1,0 +1,23 @@
+package goodspace.teaming.global.entity.aissgnment
+
+import goodspace.teaming.global.entity.BaseEntity
+import goodspace.teaming.global.entity.file.File
+import jakarta.persistence.*
+import jakarta.persistence.GenerationType.*
+import org.hibernate.annotations.SQLDelete
+import org.hibernate.annotations.SQLRestriction
+
+@Entity
+@Inheritance(strategy = InheritanceType.JOINED)
+@SQLDelete(sql = "UPDATE `submitted_file` SET deleted = true, deleted_at = NOW() WHERE id = ?")
+@SQLRestriction("deleted = false")
+class SubmittedFile(
+    @ManyToOne
+    val submission: Submission,
+    @OneToOne
+    val file: File
+) : BaseEntity() {
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    val id: Long? = null
+}


### PR DESCRIPTION
## 🔍 개요
<!--
  무엇을 변경했나요?
  왜 변경했나요? (이유/동기/관련 테켓)
-->
`File`과 `Submission`을 바로 연결하지 않고, `SubmittedFile` 엔티티를 거쳐서 연결했습니다.
엔티티의 형태와 DB 테이블의 형태를 일치시켰습니다.

## 🔗 관련 이슈
<!--
  이슈 번호 및 링크
-->
#21 
