### PR TITLE
[chore/#15] 방 생성 API가 초대 코드를 반환하도록 수정

### DIFF
--- a/src/main/kotlin/goodspace/teaming/chat/controller/ChatRestController.kt
+++ b/src/main/kotlin/goodspace/teaming/chat/controller/ChatRestController.kt
@@ -27,7 +27,7 @@ class ChatRestController(
     @PostMapping
     @Operation(
         summary = "방 생성",
-        description = "티밍룸을 생성합니다."
+        description = "티밍룸을 생성합니다. 초대 코드를 반환합니다. 초대 링크는 초대 코드를 기반으로 클라이언트 측에서 제작해주시길 바랍니다."
     )
     fun createRoom(
         principal: Principal,
@@ -132,12 +132,7 @@ class ChatRestController(
     @GetMapping("/{roomId}/messages")
     @Operation(
         summary = "메시지 이력 조회",
-        description = """
-            스크롤링을 통해 과거 메시지를 조회할 때 사용합니다.
-            현재까지 조회한 메시지 ID 중 가장 작은 값을 cursor 담으면, 그 이전에 있는 메시지를 limit만큼 반환합니다.
-            처음 조회 시에는 cursor 값을 null로 주면 됩니다.
-            limit는 1 ~ 200 사이의 값입니다.
-        """
+        description = "스크롤링을 통해 과거 메시지를 조회할 때 사용합니다. 현재까지 조회한 메시지 ID 중 가장 작은 값을 cursor 담으면, 그 이전에 있는 메시지를 limit만큼 반환합니다. 처음 조회 시에는 cursor 값을 null로 주면 됩니다. limit는 1 ~ 200 사이의 값입니다."
     )
     fun getMessages(
         principal: Principal,

--- a/src/main/kotlin/goodspace/teaming/chat/dto/RoomCreateResponseDto.kt
+++ b/src/main/kotlin/goodspace/teaming/chat/dto/RoomCreateResponseDto.kt
@@ -1,0 +1,5 @@
+package goodspace.teaming.chat.dto
+
+class RoomCreateResponseDto(
+    val inviteCode: String
+)

--- a/src/main/kotlin/goodspace/teaming/chat/service/RoomService.kt
+++ b/src/main/kotlin/goodspace/teaming/chat/service/RoomService.kt
@@ -1,15 +1,12 @@
 package goodspace.teaming.chat.service
 
-import goodspace.teaming.chat.dto.InviteAcceptRequestDto
-import goodspace.teaming.chat.dto.RoomCreateRequestDto
-import goodspace.teaming.chat.dto.RoomInfoResponseDto
-import goodspace.teaming.chat.dto.RoomSearchResponseDto
+import goodspace.teaming.chat.dto.*
 
 interface RoomService {
     fun createRoom(
         userId: Long,
         requestDto: RoomCreateRequestDto
-    )
+    ): RoomCreateResponseDto
 
     fun searchRoom(
         inviteCode: String

--- a/src/main/kotlin/goodspace/teaming/chat/service/RoomServiceImpl.kt
+++ b/src/main/kotlin/goodspace/teaming/chat/service/RoomServiceImpl.kt
@@ -4,10 +4,7 @@ import goodspace.teaming.chat.domain.InviteCodeGenerator
 import goodspace.teaming.chat.domain.mapper.RoomInfoMapper
 import goodspace.teaming.chat.domain.mapper.RoomMapper
 import goodspace.teaming.chat.domain.mapper.RoomSearchMapper
-import goodspace.teaming.chat.dto.InviteAcceptRequestDto
-import goodspace.teaming.chat.dto.RoomCreateRequestDto
-import goodspace.teaming.chat.dto.RoomInfoResponseDto
-import goodspace.teaming.chat.dto.RoomSearchResponseDto
+import goodspace.teaming.chat.dto.*
 import goodspace.teaming.chat.exception.InviteCodeAllocationFailedException
 import goodspace.teaming.global.entity.room.PaymentStatus
 import goodspace.teaming.global.entity.room.RoomRole
@@ -44,7 +41,10 @@ class RoomServiceImpl(
         maxAttempts = 3,
         backoff = Backoff(delay = 50, multiplier = 2.0)
     )
-    override fun createRoom(userId: Long, requestDto: RoomCreateRequestDto) {
+    override fun createRoom(
+        userId: Long,
+        requestDto: RoomCreateRequestDto
+    ): RoomCreateResponseDto {
         val user = userRepository.findById(userId).orElse(null)
             ?: throw IllegalArgumentException(USER_NOT_FOUND)
 
@@ -60,6 +60,8 @@ class RoomServiceImpl(
 
         // 초대 코드가 중복될 시 재시도하기 위한 플러쉬
         roomRepository.saveAndFlush(room)
+
+        return RoomCreateResponseDto(inviteCode = room.inviteCode!!)
     }
 
     @Transactional(readOnly = true)

--- a/src/test/kotlin/goodspace/teaming/chat/service/RoomServiceTest.kt
+++ b/src/test/kotlin/goodspace/teaming/chat/service/RoomServiceTest.kt
@@ -95,7 +95,7 @@ class RoomServiceTest {
             val user = mockk<User>(relaxed = true)
             every { userRepository.findById(USER_ID) } returns Optional.of(user)
 
-            val room = Room(title = "제목", type = RoomType.BASIC, memberCount = 5)
+            val room = Room(title = TITLE, type = ROOM_TYPE, memberCount = MEMBER_COUNT)
             every { roomMapper.map(any()) } returns room
 
             // 두 번까지는 중복된 초대코드를 발행하도록 설정
@@ -117,7 +117,7 @@ class RoomServiceTest {
             val user = mockk<User>(relaxed = true)
             every { userRepository.findById(USER_ID) } returns Optional.of(user)
 
-            val room = Room(title = "제목", type = RoomType.BASIC, memberCount = 5)
+            val room = Room(title = TITLE, type = ROOM_TYPE, memberCount = MEMBER_COUNT)
             every { roomMapper.map(any()) } returns room
 
             every { inviteCodeGenerator.generate() } returns DUPLICATE_CODE
@@ -126,6 +126,26 @@ class RoomServiceTest {
             // when & then
             assertThatThrownBy { roomService.createRoom(USER_ID, getRoomCreateDto()) }
                 .isInstanceOf(InviteCodeAllocationFailedException::class.java)
+        }
+
+        @Test
+        fun `초대 코드를 반환한다`() {
+            // given
+            val user = mockk<User>(relaxed = true)
+            every { userRepository.findById(USER_ID) } returns Optional.of(user)
+
+            val room = Room(title = TITLE, type = ROOM_TYPE, memberCount = MEMBER_COUNT)
+            every { roomMapper.map(any()) } returns room
+
+            every { inviteCodeGenerator.generate() } returns UNIQUE_CODE
+            every { roomRepository.existsByInviteCode(UNIQUE_CODE) } returns false
+            every { roomRepository.saveAndFlush(room) } returns room
+
+            // when
+            val responseDto = roomService.createRoom(USER_ID, getRoomCreateDto())
+
+            // then
+            assertThat(responseDto.inviteCode).isEqualTo(UNIQUE_CODE)
         }
     }
 


### PR DESCRIPTION
## 🔍 개요
<!--
  무엇을 변경했나요?
  왜 변경했나요? (이유/동기/관련 테켓)
-->
초대 코드를 즉시 화면에 렌더링하기 위해, 방 생성 API의 응답으로 제공하도록 수정했습니다.

## 🔗 관련 이슈
<!--
  이슈 번호 및 링크
-->
#15 
