### PR TITLE
[chore/#30] 초대 코드 조회 API 구현 및 기존 API 오류 수정

### DIFF
--- a/src/main/kotlin/goodspace/teaming/chat/controller/ChatRestController.kt
+++ b/src/main/kotlin/goodspace/teaming/chat/controller/ChatRestController.kt
@@ -32,12 +32,12 @@ class ChatRestController(
     fun createRoom(
         principal: Principal,
         @RequestBody requestDto: RoomCreateRequestDto
-    ): ResponseEntity<Void> {
+    ): ResponseEntity<RoomInviteCodeResponseDto> {
         val userId = principal.getUserId()
 
-        roomService.createRoom(userId, requestDto)
+        val response = roomService.createRoom(userId, requestDto)
 
-        return NO_CONTENT
+        return ResponseEntity.ok(response)
     }
 
     @GetMapping
@@ -112,6 +112,22 @@ class ChatRestController(
         val userId = principal.getUserId()
 
         val response = roomService.acceptInvite(userId, requestDto)
+
+        return ResponseEntity.ok(response)
+    }
+
+    @GetMapping("/{roomId}/invite")
+    @Operation(
+        summary = "초대 코드 조회",
+        description = "해당 티밍룸의 초대 코드를 조회합니다. 팀장만 호출할 수 있습니다."
+    )
+    fun getInviteRoom(
+        principal: Principal,
+        @PathVariable roomId: Long
+    ): ResponseEntity<RoomInviteCodeResponseDto> {
+        val userId = principal.getUserId()
+
+        val response = roomService.getInviteCode(userId, roomId)
 
         return ResponseEntity.ok(response)
     }

--- a/src/main/kotlin/goodspace/teaming/chat/dto/RoomInviteCodeResponseDto.kt
+++ b/src/main/kotlin/goodspace/teaming/chat/dto/RoomInviteCodeResponseDto.kt
@@ -1,5 +1,5 @@
 package goodspace.teaming.chat.dto
 
-class RoomCreateResponseDto(
+class RoomInviteCodeResponseDto(
     val inviteCode: String
 )

--- a/src/main/kotlin/goodspace/teaming/chat/service/RoomService.kt
+++ b/src/main/kotlin/goodspace/teaming/chat/service/RoomService.kt
@@ -6,7 +6,7 @@ interface RoomService {
     fun createRoom(
         userId: Long,
         requestDto: RoomCreateRequestDto
-    ): RoomCreateResponseDto
+    ): RoomInviteCodeResponseDto
 
     fun searchRoom(
         inviteCode: String
@@ -16,6 +16,11 @@ interface RoomService {
         userId: Long,
         requestDto: InviteAcceptRequestDto
     ): RoomInfoResponseDto
+
+    fun getInviteCode(
+        userId: Long,
+        roomId: Long
+    ): RoomInviteCodeResponseDto
 
     fun getRooms(
         userId: Long

--- a/src/test/kotlin/goodspace/teaming/chat/service/RoomServiceTest.kt
+++ b/src/test/kotlin/goodspace/teaming/chat/service/RoomServiceTest.kt
@@ -259,6 +259,48 @@ class RoomServiceTest {
     }
 
     @Nested
+    @DisplayName("getInviteCode")
+    inner class GetInviteCode {
+        @Test
+        fun `방의 초대 코드를 반환한다`() {
+            // given
+            val user = mockk<User>(relaxed = true)
+            val room = Room(title = TITLE, type = ROOM_TYPE, memberCount = MEMBER_COUNT).apply { inviteCode = INVITE_CODE }
+            val userRoom = UserRoom(
+                user = user,
+                room = room,
+                roomRole = RoomRole.LEADER
+            )
+
+            every { userRoomRepository.findByRoomIdAndUserId(ROOM_ID, USER_ID) } returns userRoom
+
+            // when
+            val responseDto = roomService.getInviteCode(USER_ID, ROOM_ID)
+
+            // then
+            assertThat(responseDto.inviteCode).isEqualTo(INVITE_CODE)
+        }
+
+        @Test
+        fun `팀장이 아니라면 예외가 발생한다`() {
+            // given
+            val user = mockk<User>(relaxed = true)
+            val room = Room(title = TITLE, type = ROOM_TYPE, memberCount = MEMBER_COUNT)
+            val userRoom = UserRoom(
+                user = user,
+                room = room,
+                roomRole = RoomRole.MEMBER
+            )
+
+            every { userRoomRepository.findByRoomIdAndUserId(ROOM_ID, USER_ID) } returns userRoom
+
+            // when & then
+            assertThatThrownBy { roomService.getInviteCode(USER_ID, ROOM_ID) }
+                .isInstanceOf(IllegalArgumentException::class.java)
+        }
+    }
+
+    @Nested
     @DisplayName("getRooms")
     inner class GetRooms {
         @Test


### PR DESCRIPTION
## 🔍 개요
<!--
  무엇을 변경했나요?
  왜 변경했나요? (이유/동기/관련 테켓)
-->
방의 초대 코드를 조회하는 API를 구현했습니다.
방 생성 API가 초대 코드를 반환하지 않던 문제를 수정했습니다.

## 🔗 관련 이슈
<!--
  이슈 번호 및 링크
-->
#30 
