### PR TITLE
[feat/#43] 첨부파일 조회 API 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -72,6 +72,9 @@ dependencies {
     // AWS & S3
     implementation(platform("software.amazon.awssdk:bom:2.33.7"))
     implementation("software.amazon.awssdk:s3")
+
+    // 테스트용 H2 DB
+    testRuntimeOnly("com.h2database:h2")
 }
 
 kotlin {

--- a/src/main/kotlin/goodspace/teaming/assignment/service/AssignmentServiceImpl.kt
+++ b/src/main/kotlin/goodspace/teaming/assignment/service/AssignmentServiceImpl.kt
@@ -9,7 +9,7 @@ import goodspace.teaming.global.entity.aissgnment.Assignment
 import goodspace.teaming.global.entity.aissgnment.AssignmentStatus.CANCELED
 import goodspace.teaming.global.entity.aissgnment.AssignmentStatus.COMPLETE
 import goodspace.teaming.global.entity.aissgnment.Submission
-import goodspace.teaming.global.entity.aissgnment.SubmittedFile
+import goodspace.teaming.global.entity.file.SubmittedFile
 import goodspace.teaming.global.entity.file.File
 import goodspace.teaming.global.entity.room.PaymentStatus.NOT_PAID
 import goodspace.teaming.global.entity.room.RoomRole

--- a/src/main/kotlin/goodspace/teaming/chat/controller/ChatRestController.kt
+++ b/src/main/kotlin/goodspace/teaming/chat/controller/ChatRestController.kt
@@ -172,9 +172,27 @@ class ChatRestController(
         principal: Principal,
         @PathVariable roomId: Long,
         @RequestBody request: MarkReadRequestDto
-    ): RoomUnreadCountResponseDto {
+    ): ResponseEntity<RoomUnreadCountResponseDto> {
         val userId = principal.getUserId()
 
-        return unreadService.markRead(userId, roomId, request.lastReadMessageId)
+        val response = unreadService.markRead(userId, roomId, request.lastReadMessageId)
+
+        return ResponseEntity.ok(response)
+    }
+
+    @GetMapping("/{roomId}/files")
+    @Operation(
+        summary = "첨부파일 조회",
+        description = "메시지로 첨부한 파일 전체를 조회합니다. 과제로 제출한 파일은 포함되지 않습니다."
+    )
+    fun getAttachments(
+        principal: Principal,
+        @PathVariable roomId: Long
+    ): ResponseEntity<List<MessageAttachmentResponseDto>> {
+        val userId = principal.getUserId()
+
+        val response = messageService.getMessageAttachment(userId, roomId)
+
+        return ResponseEntity.ok(response)
     }
 }

--- a/src/main/kotlin/goodspace/teaming/chat/domain/mapper/AttachmentMapper.kt
+++ b/src/main/kotlin/goodspace/teaming/chat/domain/mapper/AttachmentMapper.kt
@@ -25,6 +25,7 @@ class AttachmentMapper(
 
         return MessageAttachmentResponseDto(
             fileId = requireNotNull(file.id),
+            uploaderId = file.uploaderId,
             sortOrder = attachment.sortOrder,
             name = file.name,
             type = file.type,

--- a/src/main/kotlin/goodspace/teaming/chat/dto/MessageAttachmentResponseDto.kt
+++ b/src/main/kotlin/goodspace/teaming/chat/dto/MessageAttachmentResponseDto.kt
@@ -6,6 +6,7 @@ import goodspace.teaming.global.entity.file.TranscodeStatus
 
 data class MessageAttachmentResponseDto(
     val fileId: Long,
+    val uploaderId: Long,
     val sortOrder: Int,
     val name: String,
     val type: FileType,

--- a/src/main/kotlin/goodspace/teaming/chat/service/MessageService.kt
+++ b/src/main/kotlin/goodspace/teaming/chat/service/MessageService.kt
@@ -3,6 +3,7 @@ package goodspace.teaming.chat.service
 import goodspace.teaming.chat.dto.ChatMessagePageResponseDto
 import goodspace.teaming.chat.dto.ChatMessageResponseDto
 import goodspace.teaming.chat.dto.ChatSendRequestDto
+import goodspace.teaming.chat.dto.MessageAttachmentResponseDto
 
 interface MessageService {
     fun saveMessage(
@@ -17,4 +18,9 @@ interface MessageService {
         amount: Int = 50,
         beforeMessageId: Long? = null
     ): ChatMessagePageResponseDto
+
+    fun getMessageAttachment(
+        userId: Long,
+        roomId: Long
+    ): List<MessageAttachmentResponseDto>
 }

--- a/src/main/kotlin/goodspace/teaming/chat/service/MessageServiceImpl.kt
+++ b/src/main/kotlin/goodspace/teaming/chat/service/MessageServiceImpl.kt
@@ -121,7 +121,7 @@ class MessageServiceImpl(
         require(files.size == fileIds.size) { NOT_EXIST_FILE }
 
         files.forEach { file ->
-            require(file.room.id == room.id && file.user.id == user.id) { "이 방/사용자의 파일이 아닙니다." }
+            require(file.room.id == room.id && file.uploaderId == user.id) { "이 방/사용자의 파일이 아닙니다." }
             require(file.antiVirusScanStatus != AntiVirusScanStatus.INFECTED) { "악성 파일로 차단된 첨부입니다." }
         }
     }

--- a/src/main/kotlin/goodspace/teaming/file/service/S3FileUploadService.kt
+++ b/src/main/kotlin/goodspace/teaming/file/service/S3FileUploadService.kt
@@ -75,7 +75,7 @@ class S3FileUploadService(
         val file = fileRepository.save(
             File(
                 room = userRoom.room,
-                user = userRoom.user,
+                uploaderId = userRoom.user.id!!,
                 name = extractOriginalName(storedName),
                 type = mime.toFileType(),
                 mimeType = mime,

--- a/src/main/kotlin/goodspace/teaming/global/entity/aissgnment/Submission.kt
+++ b/src/main/kotlin/goodspace/teaming/global/entity/aissgnment/Submission.kt
@@ -1,6 +1,7 @@
 package goodspace.teaming.global.entity.aissgnment
 
 import goodspace.teaming.global.entity.BaseEntity
+import goodspace.teaming.global.entity.file.SubmittedFile
 import jakarta.persistence.*
 import jakarta.persistence.CascadeType.*
 import jakarta.persistence.FetchType.*

--- a/src/main/kotlin/goodspace/teaming/global/entity/file/File.kt
+++ b/src/main/kotlin/goodspace/teaming/global/entity/file/File.kt
@@ -4,7 +4,6 @@ import goodspace.teaming.global.entity.BaseEntity
 import goodspace.teaming.global.entity.file.AntiVirusScanStatus.PASSED
 import goodspace.teaming.global.entity.file.TranscodeStatus.NONE
 import goodspace.teaming.global.entity.room.Room
-import goodspace.teaming.global.entity.user.User
 import jakarta.persistence.*
 import jakarta.persistence.EnumType.STRING
 import jakarta.persistence.GenerationType.IDENTITY
@@ -19,9 +18,8 @@ class File(
     @JoinColumn(nullable = false)
     val room: Room,
 
-    @ManyToOne
-    @JoinColumn(nullable = false)
-    val user: User,
+    @Column(nullable = false)
+    val uploaderId: Long,
 
     @Column(nullable = false)
     var name: String,

--- a/src/main/kotlin/goodspace/teaming/global/entity/file/SubmittedFile.kt
+++ b/src/main/kotlin/goodspace/teaming/global/entity/file/SubmittedFile.kt
@@ -1,7 +1,7 @@
-package goodspace.teaming.global.entity.aissgnment
+package goodspace.teaming.global.entity.file
 
 import goodspace.teaming.global.entity.BaseEntity
-import goodspace.teaming.global.entity.file.File
+import goodspace.teaming.global.entity.aissgnment.Submission
 import jakarta.persistence.*
 import jakarta.persistence.GenerationType.*
 import org.hibernate.annotations.SQLDelete

--- a/src/main/kotlin/goodspace/teaming/global/entity/room/Room.kt
+++ b/src/main/kotlin/goodspace/teaming/global/entity/room/Room.kt
@@ -43,6 +43,9 @@ class Room(
     @OneToMany(fetch = LAZY, mappedBy = "room", cascade = [ALL], orphanRemoval = true)
     val assignments: MutableList<Assignment> = mutableListOf()
 
+    @OneToMany(fetch = LAZY, mappedBy = "room", cascade = [ALL], orphanRemoval = true)
+    val messages: MutableList<Message> = mutableListOf()
+
     var success: Boolean = false
 
     fun isEmpty(): Boolean {

--- a/src/test/kotlin/goodspace/teaming/chat/domain/mapper/ChatMessageResponseMapperTest.kt
+++ b/src/test/kotlin/goodspace/teaming/chat/domain/mapper/ChatMessageResponseMapperTest.kt
@@ -206,6 +206,7 @@ class ChatMessageResponseMapperTest {
 
         return MessageAttachmentResponseDto(
             fileId = fileId,
+            uploaderId = user.id!!,
             sortOrder = sortOrder,
             name = file.name,
             type = file.type,

--- a/src/test/kotlin/goodspace/teaming/email/service/EmailVerificationServiceTest.kt
+++ b/src/test/kotlin/goodspace/teaming/email/service/EmailVerificationServiceTest.kt
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.context.event.ApplicationEvents
 import org.springframework.test.context.event.RecordApplicationEvents
 import org.springframework.transaction.annotation.Transactional
@@ -28,6 +29,7 @@ private const val DEFAULT_PASSWORD = "defaultPassword"
 @SpringBootTest
 @RecordApplicationEvents
 @Transactional
+@ActiveProfiles("test")
 class EmailVerificationServiceTest(
     @Autowired
     private val emailVerificationService: EmailVerificationService,

--- a/src/test/kotlin/goodspace/teaming/fixture/FileFixture.kt
+++ b/src/test/kotlin/goodspace/teaming/fixture/FileFixture.kt
@@ -55,7 +55,7 @@ enum class FileFixture(
     fun getInstanceWith(room: Room, user: User): File {
         return File(
             room = room,
-            user = user,
+            uploaderId = user.id!!,
             name = filename,
             type = type,
             mimeType = mimeType,


### PR DESCRIPTION
## 🔍 개요
<!--
  무엇을 변경했나요?
  왜 변경했나요? (이유/동기/관련 테켓)
-->
티밍룸 내 모든 첨부파일을 조회하는 API를 구현했습니다.
기존에 통합 테스트를 사용하던 클래스에서 관리자 계정과의 충돌이 발생해, 메모리 DB를 사용하도록 설정했습니다.
`File`이 `User`와 직접 연결되는 대신, `User.id`만을 참조하도록 수정했습니다.
`SubmittedFile`의 위치를 `assignment` 패키지에서 `file` 패키지로 변경했습니다.

## 🔗 관련 이슈
<!--
  이슈 번호 및 링크
-->
#43 