### PR TITLE
[feat/#61] 엑세스 토큰 재발급 API 구현

### DIFF
--- a/src/main/kotlin/goodspace/teaming/authorization/controller/TokenManagementController.kt
+++ b/src/main/kotlin/goodspace/teaming/authorization/controller/TokenManagementController.kt
@@ -1,0 +1,34 @@
+package goodspace.teaming.authorization.controller
+
+import goodspace.teaming.authorization.dto.AccessTokenReissueRequestDto
+import goodspace.teaming.authorization.dto.AccessTokenResponseDto
+import goodspace.teaming.authorization.service.TokenManagementService
+import io.swagger.v3.oas.annotations.Operation
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/auth/token")
+@Tag(
+    name = "JWT 관리 API"
+)
+class TokenManagementController(
+    private val tokenManagementService: TokenManagementService
+) {
+    @PostMapping("/access-token")
+    @Operation(
+        summary = "엑세스 토큰 재발급",
+        description = "리프레쉬 토큰을 통해 엑세스 토큰을 재발급합니다."
+    )
+    fun reissueAccessToken(
+        @RequestBody requestDto: AccessTokenReissueRequestDto
+    ): ResponseEntity<AccessTokenResponseDto> {
+        val response = tokenManagementService.reissueAccessToken(requestDto)
+
+        return ResponseEntity.ok(response)
+    }
+}

--- a/src/main/kotlin/goodspace/teaming/authorization/dto/AccessTokenReissueRequestDto.kt
+++ b/src/main/kotlin/goodspace/teaming/authorization/dto/AccessTokenReissueRequestDto.kt
@@ -1,0 +1,5 @@
+package goodspace.teaming.authorization.dto
+
+data class AccessTokenReissueRequestDto(
+    val refreshToken: String
+)

--- a/src/main/kotlin/goodspace/teaming/authorization/dto/AccessTokenResponseDto.kt
+++ b/src/main/kotlin/goodspace/teaming/authorization/dto/AccessTokenResponseDto.kt
@@ -1,0 +1,5 @@
+package goodspace.teaming.authorization.dto
+
+data class AccessTokenResponseDto(
+    val accessToken: String
+)

--- a/src/main/kotlin/goodspace/teaming/authorization/service/TokenManagementService.kt
+++ b/src/main/kotlin/goodspace/teaming/authorization/service/TokenManagementService.kt
@@ -1,0 +1,44 @@
+package goodspace.teaming.authorization.service
+
+import goodspace.teaming.authorization.dto.AccessTokenReissueRequestDto
+import goodspace.teaming.authorization.dto.AccessTokenResponseDto
+import goodspace.teaming.global.entity.user.User
+import goodspace.teaming.global.repository.UserRepository
+import goodspace.teaming.global.security.TokenProvider
+import goodspace.teaming.global.security.TokenType
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+private const val USER_NOT_FOUND = "회원을 조회할 수 없습니다."
+private const val ILLEGAL_TOKEN = "부적절한 토큰입니다."
+private const val EXPIRED_REFRESH_TOKEN = "만료된 리프레쉬 토큰입니다."
+
+@Service
+class TokenManagementService(
+    private val userRepository: UserRepository,
+    private val tokenProvider: TokenProvider
+) {
+    @Transactional(readOnly = true)
+    fun reissueAccessToken(requestDto: AccessTokenReissueRequestDto): AccessTokenResponseDto {
+        val refreshToken = requestDto.refreshToken
+
+        val userId = tokenProvider.getIdFromToken(refreshToken)
+        val user = findUser(userId)
+
+        assertRefreshToken(user, refreshToken)
+
+        val accessToken = tokenProvider.createToken(user.id!!, TokenType.ACCESS, user.roles)
+
+        return AccessTokenResponseDto(accessToken)
+    }
+
+    private fun assertRefreshToken(user: User, refreshToken: String) {
+        require(tokenProvider.validateToken(refreshToken, TokenType.REFRESH)) { ILLEGAL_TOKEN }
+        require(user.token == refreshToken) { EXPIRED_REFRESH_TOKEN }
+    }
+
+    private fun findUser(userId: Long): User {
+        return userRepository.findById(userId)
+            .orElseThrow { IllegalArgumentException(USER_NOT_FOUND) }
+    }
+}

--- a/src/main/kotlin/goodspace/teaming/global/entity/user/User.kt
+++ b/src/main/kotlin/goodspace/teaming/global/entity/user/User.kt
@@ -40,7 +40,7 @@ abstract class User(
     private val refreshToken: RefreshToken = RefreshToken()
 
     @OneToMany(mappedBy = "user", fetch = LAZY, cascade = [ALL], orphanRemoval = true)
-    private val roles = mutableListOf<UserRole>()
+    private val userRoles = mutableListOf<UserRole>()
 
     @OneToMany(mappedBy = "user", fetch = LAZY, cascade = [ALL], orphanRemoval = true)
     val userRooms = mutableListOf<UserRoom>()
@@ -51,16 +51,19 @@ abstract class User(
             refreshToken.tokenValue = value
         }
 
+    val roles: List<Role>
+        get() = userRoles.map { it.role }
+
     fun addUserRoom(userRoom: UserRoom) {
         userRooms.add(userRoom)
     }
 
     fun addRole(vararg role: UserRole) {
-        roles.addAll(role)
+        userRoles.addAll(role)
     }
 
     fun addRole(role: Role) {
         val userRole = UserRole(this, role)
-        roles.add(userRole)
+        userRoles.add(userRole)
     }
 }

--- a/src/test/kotlin/goodspace/teaming/authorization/service/TokenManagementServiceTest.kt
+++ b/src/test/kotlin/goodspace/teaming/authorization/service/TokenManagementServiceTest.kt
@@ -1,0 +1,88 @@
+package goodspace.teaming.authorization.service
+
+import goodspace.teaming.authorization.dto.AccessTokenReissueRequestDto
+import goodspace.teaming.global.repository.UserRepository
+import goodspace.teaming.global.security.TokenProvider
+import goodspace.teaming.global.security.TokenType
+import goodspace.teaming.util.createUser
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.assertj.core.api.Assertions.assertThatThrownBy
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import java.util.*
+
+private const val REFRESH_TOKEN = "refreshToken"
+private const val DIFFERENT_REFRESH_TOKEN = "differentRefreshToken"
+private const val ACCESS_TOKEN = "accessToken"
+
+class TokenManagementServiceTest {
+    private val userRepository = mockk<UserRepository>()
+    private val tokenProvider = mockk<TokenProvider>()
+
+    private val tokenManagementService = TokenManagementService(
+        userRepository = userRepository,
+        tokenProvider = tokenProvider
+    )
+
+    @Nested
+    @DisplayName("reissueAccessToken")
+    inner class ReissueAccessToken {
+        @Test
+        fun `엑세스 토큰을 재발급한다`() {
+            // given
+            val user = createUser()
+            user.token = REFRESH_TOKEN
+
+            val requestDto = AccessTokenReissueRequestDto(REFRESH_TOKEN)
+
+            every { tokenProvider.getIdFromToken(REFRESH_TOKEN) } returns user.id!!
+            every { userRepository.findById(user.id!!) } returns Optional.of(user)
+            every { tokenProvider.validateToken(REFRESH_TOKEN, TokenType.REFRESH) } returns true
+            every { tokenProvider.createToken(user.id!!, TokenType.ACCESS, any()) } returns ACCESS_TOKEN
+
+            // when
+            val response = tokenManagementService.reissueAccessToken(requestDto)
+
+            // then
+            assertThat(response.accessToken).isEqualTo(ACCESS_TOKEN)
+        }
+
+        @Test
+        fun `리프레쉬 토큰이 부적절하면 예외를 던진다`() {
+            // given
+            val user = createUser()
+            user.token = REFRESH_TOKEN
+
+            val requestDto = AccessTokenReissueRequestDto(REFRESH_TOKEN)
+
+            every { tokenProvider.getIdFromToken(REFRESH_TOKEN) } returns user.id!!
+            every { userRepository.findById(user.id!!) } returns Optional.of(user)
+            every { tokenProvider.validateToken(REFRESH_TOKEN, TokenType.REFRESH) } returns false
+
+            // when & then
+            assertThatThrownBy { tokenManagementService.reissueAccessToken(requestDto) }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessage("부적절한 토큰입니다.")
+        }
+
+        @Test
+        fun `회원의 리프레쉬 토큰과 일치하지 않으면 예외를 던진다`() {
+            val user = createUser()
+            user.token = REFRESH_TOKEN
+
+            val requestDto = AccessTokenReissueRequestDto(DIFFERENT_REFRESH_TOKEN)
+
+            every { tokenProvider.getIdFromToken(DIFFERENT_REFRESH_TOKEN) } returns user.id!!
+            every { userRepository.findById(user.id!!) } returns Optional.of(user)
+            every { tokenProvider.validateToken(DIFFERENT_REFRESH_TOKEN, TokenType.REFRESH) } returns true
+
+            // when & then
+            assertThatThrownBy { tokenManagementService.reissueAccessToken(requestDto) }
+                .isInstanceOf(IllegalArgumentException::class.java)
+                .hasMessage("만료된 리프레쉬 토큰입니다.")
+        }
+    }
+}

--- a/src/test/kotlin/goodspace/teaming/chat/domain/mapper/SenderSummaryMapperTest.kt
+++ b/src/test/kotlin/goodspace/teaming/chat/domain/mapper/SenderSummaryMapperTest.kt
@@ -97,7 +97,7 @@ class SenderSummaryMapperTest {
 
             // then
             assertThat(result.avatarUrl).isNull()
-            verify { urlProvider.publicUrl(null, null, DEFAULT_SIZE) }
+            verify { urlProvider.publicUrl(null, 0, DEFAULT_SIZE) }
             confirmVerified(urlProvider)
         }
     }

--- a/src/test/kotlin/goodspace/teaming/util/CreateUtil.kt
+++ b/src/test/kotlin/goodspace/teaming/util/CreateUtil.kt
@@ -1,0 +1,24 @@
+package goodspace.teaming.util
+
+import goodspace.teaming.fixture.USER_EMAIL
+import goodspace.teaming.fixture.USER_ID
+import goodspace.teaming.fixture.USER_NAME
+import goodspace.teaming.fixture.USER_PASSWORD
+import goodspace.teaming.global.entity.user.TeamingUser
+import org.springframework.test.util.ReflectionTestUtils
+
+fun createUser(
+    email: String = USER_EMAIL,
+    name: String = USER_NAME,
+    password: String = USER_PASSWORD,
+    id: Long = USER_ID
+): TeamingUser {
+    val user = TeamingUser(
+        email = email,
+        name = name,
+        password = password
+    )
+    ReflectionTestUtils.setField(user, "id", id)
+
+    return user
+}


### PR DESCRIPTION
## 🔍 개요
<!--
  무엇을 변경했나요?
  왜 변경했나요? (이유/동기/관련 테켓)
-->
리프레쉬 토큰을 통해 엑세스 토큰을 재발급하는 API를 구현했습니다.

## 🔗 관련 이슈
<!--
  이슈 번호 및 링크
-->
#61 