### PR TITLE
[chore/#63] 소셜 회원은 이메일을 수정할 수 없도록 수정

### DIFF
--- a/src/main/kotlin/goodspace/teaming/user/service/UserServiceImpl.kt
+++ b/src/main/kotlin/goodspace/teaming/user/service/UserServiceImpl.kt
@@ -2,6 +2,7 @@ package goodspace.teaming.user.service
 
 import goodspace.teaming.global.entity.user.TeamingUser
 import goodspace.teaming.global.entity.user.User
+import goodspace.teaming.global.entity.user.UserType
 import goodspace.teaming.global.password.PasswordValidator
 import goodspace.teaming.global.repository.EmailVerificationRepository
 import goodspace.teaming.global.repository.UserRepository
@@ -12,6 +13,7 @@ import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 private const val USER_NOT_FOUND = "회원을 조회할 수 없습니다."
+private const val ILLEGAL_USER_TYPE = "소셜 회원은 이메일을 변경할 수 없습니다."
 private const val EMAIL_ALREADY_EXISTS = "이미 사용 중인 이메일입니다."
 private const val EMAIL_NOT_VERIFIED = "인증되지 않은 이메일입니다."
 private const val WRONG_PASSWORD = "비밀번호가 올바르지 않습니다."
@@ -37,6 +39,7 @@ class UserServiceImpl(
         val user = findUser(userId)
         val email = requestDto.email
 
+        checkUserType(user)
         checkEmailAlreadyExists(email)
         checkEmailVerification(email)
 
@@ -72,6 +75,10 @@ class UserServiceImpl(
     private fun findTeamingUser(userId: Long): TeamingUser {
         return userRepository.findTeamingUserById(userId)
             ?: throw IllegalArgumentException(USER_NOT_FOUND)
+    }
+
+    private fun checkUserType(user: User) {
+        check(user.type == UserType.TEAMING) { ILLEGAL_USER_TYPE }
     }
 
     private fun checkEmailAlreadyExists(email: String) {

--- a/src/test/kotlin/goodspace/teaming/fixture/EmailVerificationConstants.kt
+++ b/src/test/kotlin/goodspace/teaming/fixture/EmailVerificationConstants.kt
@@ -3,5 +3,6 @@ package goodspace.teaming.fixture
 import java.time.LocalDateTime
 
 const val EMAIL_VERIFICATION_ID = 3456L
+const val EMAIL_VERIFICATION_EMAIL = "emailVerification@email.com"
 const val EMAIL_VERIFICATION_CODE = "123456"
 val EMAIL_VERIFICATION_EXPIRES_AT: LocalDateTime = LocalDateTime.now().plusMinutes(5)

--- a/src/test/kotlin/goodspace/teaming/util/CreateUtil.kt
+++ b/src/test/kotlin/goodspace/teaming/util/CreateUtil.kt
@@ -1,16 +1,17 @@
 package goodspace.teaming.util
 
-import goodspace.teaming.fixture.USER_EMAIL
-import goodspace.teaming.fixture.USER_ID
-import goodspace.teaming.fixture.USER_NAME
-import goodspace.teaming.fixture.USER_PASSWORD
+import goodspace.teaming.fixture.*
+import goodspace.teaming.global.entity.email.EmailVerification
 import goodspace.teaming.global.entity.user.TeamingUser
+import goodspace.teaming.global.entity.user.UserType
 import org.springframework.test.util.ReflectionTestUtils
+import java.time.LocalDateTime
 
 fun createUser(
     email: String = USER_EMAIL,
     name: String = USER_NAME,
     password: String = USER_PASSWORD,
+    type: UserType = UserType.TEAMING,
     id: Long = USER_ID
 ): TeamingUser {
     val user = TeamingUser(
@@ -18,7 +19,26 @@ fun createUser(
         name = name,
         password = password
     )
+    ReflectionTestUtils.setField(user, "type", type)
     ReflectionTestUtils.setField(user, "id", id)
 
     return user
+}
+
+fun createEmailVerification(
+    email: String = EMAIL_VERIFICATION_EMAIL,
+    verified: Boolean = true,
+    code: String = EMAIL_VERIFICATION_CODE,
+    expiresAt: LocalDateTime = EMAIL_VERIFICATION_EXPIRES_AT,
+    id: Long = EMAIL_VERIFICATION_ID
+): EmailVerification {
+    val emailVerification = EmailVerification(
+        email = email,
+        verified = verified,
+        code = code,
+        expiresAt = expiresAt
+    )
+    ReflectionTestUtils.setField(emailVerification, "id", id)
+
+    return emailVerification
 }


### PR DESCRIPTION
## 🔍 개요
<!--
  무엇을 변경했나요?
  왜 변경했나요? (이유/동기/관련 테켓)
-->
소셜 회원이 이메일을 수정하려 할 경우 예외를 던지도록 검증 로직을 추가했습니다.

## 🔗 관련 이슈
<!--
  이슈 번호 및 링크
-->
#63 