### PR TITLE
[fix] 잘못된 경로의 클래스를 import하던 문제 수정

### DIFF
--- a/src/main/kotlin/goodspace/teaming/file/controller/AvatarController.kt
+++ b/src/main/kotlin/goodspace/teaming/file/controller/AvatarController.kt
@@ -4,13 +4,9 @@ import goodspace.teaming.file.dto.*
 import goodspace.teaming.file.service.AvatarService
 import goodspace.teaming.global.security.getUserId
 import io.swagger.v3.oas.annotations.Operation
-import io.swagger.v3.oas.annotations.parameters.RequestBody
 import io.swagger.v3.oas.annotations.tags.Tag
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.DeleteMapping
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 import java.security.Principal
 
 @RestController


### PR DESCRIPTION
## 🔍 개요
<!--
  무엇을 변경했나요?
  왜 변경했나요? (이유/동기/관련 테켓)
-->
Spring의 `RequestBody` 대신 Swagger의 `RequestBody`를 사용하던 문제를 해결했습니다.