### PR TITLE
[feature/#66] 개행 문자 방어로직 추가

### DIFF
--- a/src/main/kotlin/goodspace/teaming/authorization/service/AppleAuthService.kt
+++ b/src/main/kotlin/goodspace/teaming/authorization/service/AppleAuthService.kt
@@ -235,6 +235,9 @@ class AppleAuthService(
 
     private fun getECPrivateKeyFrom(pem: String): ECPrivateKey {
         val trimmedPem = pem
+            .trim()
+            .removeSurrounding("\"")
+            .replaceEscape()
             .replace(PEM_PREFIX_PKCS8, "")
             .replace(PEM_SUFFIX_PKCS8, "")
             .replace(PEM_PREFIX_EC, "")
@@ -246,6 +249,12 @@ class AppleAuthService(
 
         return KeyFactory.getInstance("EC").generatePrivate(keySpec)
                 as ECPrivateKey
+    }
+
+    private fun String.replaceEscape(): String {
+        return this
+            .replace("\\r", "\r")
+            .replace("\\n", "\n")
     }
 
     private fun String.signEs256With(privateKey: ECPrivateKey): ByteArray {


### PR DESCRIPTION
## 🔍 개요
<!--
  무엇을 변경했나요?
  왜 변경했나요? (이유/동기/관련 테켓)
-->
`.env`에 포함된 환경변수의 이스케이프 문자로 인해 애플 OAuth가 오동작하는 문제를 해결했습니다.

## 🔗 관련 이슈
<!--
  이슈 번호 및 링크
-->
#66 