### PR TITLE
[feat/#1] 리엑트 네이티브를 위한 엔드포인트 추가

### DIFF
--- a/src/main/kotlin/goodspace/teaming/global/websocket/StompConfig.kt
+++ b/src/main/kotlin/goodspace/teaming/global/websocket/StompConfig.kt
@@ -19,7 +19,12 @@ class StompConfig(
     }
 
     override fun registerStompEndpoints(registry: StompEndpointRegistry) {
+        // 네이티브 WebSocket (RN/모바일 용)
         registry.addEndpoint("/ws")
+            .setAllowedOriginPatterns("*")
+
+        // SockJS (웹 브라우저 용)
+        registry.addEndpoint("/ws-sockjs")
             .setAllowedOriginPatterns("*")
             .withSockJS()
     }


### PR DESCRIPTION
## 🔍 개요
<!--
  무엇을 변경했나요?
  왜 변경했나요? (이유/동기/관련 테켓)
-->
웹소캣 핸드셰이크 엔드포인트를 추가했습니다.
기존에 SockJs를 사용하던 웹용 엔드포인트를 `/ws`에서 `/ws-sockjs`로 변경했습니다.
리액트 네이티브 환경을 위한 네이티브 웹소캣 엔드포인트를 `/ws`로 추가했습니다.

## 🔗 관련 이슈
<!--
  이슈 번호 및 링크
-->
#1 