### PR TITLE
[chore/#106] CONNECT 프레임에 사용한 인증 정보를 세션에 저장

### DIFF
--- a/src/main/kotlin/goodspace/teaming/global/websocket/JwtStompChannelInterceptor.kt
+++ b/src/main/kotlin/goodspace/teaming/global/websocket/JwtStompChannelInterceptor.kt
@@ -12,58 +12,97 @@ import org.springframework.messaging.simp.stomp.StompHeaderAccessor
 import org.springframework.messaging.support.ChannelInterceptor
 import org.springframework.messaging.support.MessageBuilder
 import org.springframework.stereotype.Component
+import java.security.Principal
+import kotlin.math.min
 
 private const val ROOM_SUBSCRIBE_PREFIX = "/topic/rooms/"
 private const val ROOM_SEND_PREFIX = "/app/rooms/"
+private const val AUTH_HEADER = "Authorization"
+private const val AUTH_SESSION_KEY = "WS_AUTHENTICATION"
+private const val MAX_LOG_PAYLOAD_LENGTH = 512
 
 @Component
 class JwtStompChannelInterceptor(
     private val tokenProvider: TokenProvider,
     private val roomAccessAuthorizer: RoomAccessAuthorizer
 ) : ChannelInterceptor {
+
     private val log = LoggerFactory.getLogger(JwtStompChannelInterceptor::class.java)
 
     override fun preSend(message: Message<*>, channel: MessageChannel): Message<*>? {
         val accessor = StompHeaderAccessor.wrap(message)
 
-        if (accessor.command == StompCommand.CONNECT) {
-            val token = getTokenFromNativeHeader(accessor, "Authorization")
-            validateToken(token)
-
-            setAuthenticationOnAccessor(accessor, token)
-
-            log.info("웹소켓 CONNECT userId=${accessor.user?.getUserId()}")
-        }
-
-        if (accessor.command == StompCommand.SUBSCRIBE) {
-            val destination = accessor.destination.orEmpty()
-
-            if (destination.startsWith(ROOM_SUBSCRIBE_PREFIX)) {
-                val roomId = getRoomIdFromDestination(destination)
-
-                val userId = accessor.user?.getUserId()
-                    ?: throw IllegalStateException("인증 정보 없음")
-
-                roomAccessAuthorizer.assertMemberOf(roomId, userId)
-                log.info("웹소켓 SUBSCRIBE userId=$userId roomId=$roomId")
-            }
-        }
-
-        if (accessor.command == StompCommand.SEND) {
-            val destination = accessor.destination.orEmpty()
-            if (destination.startsWith(ROOM_SEND_PREFIX) && destination.endsWith("/send")) {
-                val roomId = destination.removePrefix(ROOM_SEND_PREFIX).substringBefore('/').toLongOrNull()
-                    ?: throw IllegalArgumentException("잘못된 발행 경로: $destination")
-
-                val userId = accessor.user?.getUserId()
-                    ?: throw IllegalStateException("인증 정보 없음")
-
-                roomAccessAuthorizer.assertMemberOf(roomId, userId)
-                log.info("웹소켓 SEND userId=$userId roomId=$roomId payload=${message.payload}")
-            }
+        when (accessor.command) {
+            StompCommand.CONNECT -> handleConnect(accessor)
+            StompCommand.SUBSCRIBE -> handleSubscribe(accessor)
+            StompCommand.SEND -> handleSend(accessor, message)
+            else -> { /* no-op */ }
         }
 
         return MessageBuilder.createMessage(message.payload, accessor.messageHeaders)
+    }
+
+    private fun handleConnect(accessor: StompHeaderAccessor) {
+        val token = getTokenFromNativeHeader(accessor, AUTH_HEADER)
+        validateToken(token)
+
+        val authentication = tokenProvider.getAuthentication(token)
+        accessor.user = authentication
+        accessor.sessionAttributes?.put(AUTH_SESSION_KEY, authentication)
+
+        log.info("웹소켓 CONNECT userId=${authentication.getUserId()}")
+    }
+
+    private fun handleSubscribe(accessor: StompHeaderAccessor) {
+        ensurePrincipal(accessor)
+
+        val destination = accessor.destination.orEmpty()
+        if (destination.startsWith(ROOM_SUBSCRIBE_PREFIX)) {
+            val roomId = getRoomIdFromDestination(destination)
+            val userId = accessor.user?.getUserId()
+                ?: throw IllegalStateException("인증 정보 없음")
+
+            roomAccessAuthorizer.assertMemberOf(roomId, userId)
+            log.info("웹소켓 SUBSCRIBE userId=$userId roomId=$roomId")
+        }
+    }
+
+    private fun handleSend(accessor: StompHeaderAccessor, message: Message<*>) {
+        ensurePrincipal(accessor)
+
+        val destination = accessor.destination.orEmpty()
+        if (destination.startsWith(ROOM_SEND_PREFIX) && destination.endsWith("/send")) {
+            val roomId = destination.removePrefix(ROOM_SEND_PREFIX).substringBefore('/').toLongOrNull()
+                ?: throw IllegalArgumentException("잘못된 발행 경로: $destination")
+
+            val userId = accessor.user?.getUserId()
+                ?: throw IllegalStateException("인증 정보 없음")
+
+            roomAccessAuthorizer.assertMemberOf(roomId, userId)
+            log.info(
+                "웹소켓 SEND userId=$userId roomId=$roomId payload=${formatPayloadForLog(message.payload)}"
+            )
+        }
+    }
+
+    /**
+     * CONNECT 이후 프레임에서 accessor.user 가 누락될 수 있으니
+     * 1) 세션에서 복원하고, 2) (옵션) 프레임에 Authorization 헤더가 있으면 재인증 지원
+     */
+    private fun ensurePrincipal(accessor: StompHeaderAccessor) {
+        if (accessor.user != null) return
+
+        val sessionAuth = accessor.sessionAttributes?.get(AUTH_SESSION_KEY)
+        if (sessionAuth is Principal) {
+            accessor.user = sessionAuth
+            return
+        }
+
+        val token = getTokenFromNativeHeader(accessor, AUTH_HEADER)
+        if (token.isNotBlank() && tokenProvider.validateToken(token, TokenType.ACCESS)) {
+            accessor.user = tokenProvider.getAuthentication(token)
+            accessor.sessionAttributes?.put(AUTH_SESSION_KEY, accessor.user!!)
+        }
     }
 
     private fun getTokenFromNativeHeader(
@@ -71,7 +110,6 @@ class JwtStompChannelInterceptor(
         headerName: String
     ): String {
         val rawToken = accessor.getFirstNativeHeader(headerName).orEmpty()
-
         return rawToken
             .removePrefix("Bearer ")
             .ifEmpty { rawToken.removePrefix("bearer ") }
@@ -79,18 +117,25 @@ class JwtStompChannelInterceptor(
     }
 
     private fun validateToken(token: String) {
-        require(token.isNotBlank() && tokenProvider.validateToken(token, TokenType.ACCESS)) { "부적절한 토큰입니다." }
-    }
-
-    private fun setAuthenticationOnAccessor(
-        accessor: StompHeaderAccessor,
-        token: String
-    ) {
-        accessor.user = tokenProvider.getAuthentication(token)
+        require(token.isNotBlank() && tokenProvider.validateToken(token, TokenType.ACCESS)) {
+            "부적절한 토큰입니다."
+        }
     }
 
     private fun getRoomIdFromDestination(destination: String): Long {
-        return destination.removePrefix(ROOM_SUBSCRIBE_PREFIX).substringBefore('/').toLongOrNull()
+        return destination.removePrefix(ROOM_SUBSCRIBE_PREFIX)
+            .substringBefore('/')
+            .toLongOrNull()
             ?: throw IllegalArgumentException("잘못된 구독 경로: $destination")
+    }
+
+    private fun formatPayloadForLog(payload: Any?): String {
+        if (payload == null) return "null"
+        val text = when (payload) {
+            is ByteArray -> runCatching { String(payload) }.getOrElse { "<binary:${payload.size} bytes>" }
+            else -> payload.toString()
+        }
+        val end = min(text.length, MAX_LOG_PAYLOAD_LENGTH)
+        return if (end < text.length) text.substring(0, end) + "...(truncated)" else text
     }
 }


### PR DESCRIPTION
## 🔍 개요
<!--
  무엇을 변경했나요?
  왜 변경했나요? (이유/동기/관련 테켓)
-->
SUBSCRIBE 프레임에서 인증 정보가 누락되어 문제가 발생하고 있어, 인증 정보를 세션에 저장하는 방식으로 수정합니다.

## 🔗 관련 이슈
<!--
  이슈 번호 및 링크
-->
#106