### PR TITLE
[fix/#124] 아바타 API 요청으로 OwnerType 추가

### DIFF
--- a/src/main/kotlin/goodspace/teaming/file/controller/AvatarController.kt
+++ b/src/main/kotlin/goodspace/teaming/file/controller/AvatarController.kt
@@ -1,6 +1,5 @@
 package goodspace.teaming.file.controller
 
-import goodspace.teaming.file.domain.AvatarOwnerType
 import goodspace.teaming.file.dto.*
 import goodspace.teaming.file.service.AvatarService
 import goodspace.teaming.global.security.getUserId
@@ -41,7 +40,9 @@ class AvatarController(
         @RequestBody requestDto: AvatarUploadIntentRequestDto
     ): ResponseEntity<AvatarUploadIntentResponseDto> {
         val userId = principal.getUserId()
-        val res = avatarService.intent(AvatarOwnerType.USER, userId, requestDto)
+
+        val res = avatarService.intent(userId, requestDto)
+
         return ResponseEntity.ok(res)
     }
 
@@ -62,7 +63,9 @@ class AvatarController(
         @RequestBody requestDto: AvatarUploadCompleteRequestDto
     ): ResponseEntity<AvatarUploadCompleteResponseDto> {
         val userId = principal.getUserId()
-        val res = avatarService.complete(AvatarOwnerType.USER, userId, requestDto)
+
+        val res = avatarService.complete(userId, requestDto)
+
         return ResponseEntity.ok(res)
     }
 
@@ -75,10 +78,13 @@ class AvatarController(
         """
     )
     fun issueViewUrl(
-        principal: Principal
+        principal: Principal,
+        @RequestBody ownerTypeDto: AvatarOwnerTypeDto
     ): ResponseEntity<AvatarUrlResponseDto> {
         val userId = principal.getUserId()
-        val res = avatarService.issueViewUrl(AvatarOwnerType.USER, userId)
+
+        val res = avatarService.issueViewUrl(userId, ownerTypeDto)
+
         return ResponseEntity.ok(res)
     }
 
@@ -91,10 +97,13 @@ class AvatarController(
         """
     )
     fun delete(
-        principal: Principal
+        principal: Principal,
+        @RequestBody ownerTypeDto: AvatarOwnerTypeDto
     ): ResponseEntity<Void> {
         val userId = principal.getUserId()
-        avatarService.delete(AvatarOwnerType.USER, userId)
+
+        avatarService.delete(userId, ownerTypeDto)
+
         return ResponseEntity.noContent().build()
     }
 }

--- a/src/main/kotlin/goodspace/teaming/file/dto/AvatarOwnerTypeDto.kt
+++ b/src/main/kotlin/goodspace/teaming/file/dto/AvatarOwnerTypeDto.kt
@@ -1,0 +1,7 @@
+package goodspace.teaming.file.dto
+
+import goodspace.teaming.file.domain.AvatarOwnerType
+
+data class AvatarOwnerTypeDto(
+    val ownerType: AvatarOwnerType
+)

--- a/src/main/kotlin/goodspace/teaming/file/service/AvatarService.kt
+++ b/src/main/kotlin/goodspace/teaming/file/service/AvatarService.kt
@@ -1,28 +1,25 @@
 package goodspace.teaming.file.service
 
-import goodspace.teaming.file.domain.AvatarOwnerType
 import goodspace.teaming.file.dto.*
 
 interface AvatarService {
     fun intent(
-        ownerType: AvatarOwnerType,
         ownerId: Long,
-        request: AvatarUploadIntentRequestDto
+        requestDto: AvatarUploadIntentRequestDto
     ): AvatarUploadIntentResponseDto
 
     fun complete(
-        ownerType: AvatarOwnerType,
         ownerId: Long,
-        request: AvatarUploadCompleteRequestDto
+        requestDto: AvatarUploadCompleteRequestDto
     ): AvatarUploadCompleteResponseDto
 
     fun issueViewUrl(
-        ownerType: AvatarOwnerType,
-        ownerId: Long
+        ownerId: Long,
+        ownerTypeDto: AvatarOwnerTypeDto
     ): AvatarUrlResponseDto
 
     fun delete(
-        ownerType: AvatarOwnerType,
-        ownerId: Long
+        ownerId: Long,
+        ownerTypeDto: AvatarOwnerTypeDto
     )
 }


### PR DESCRIPTION
## 🔍 개요
<!--
  무엇을 변경했나요?
  왜 변경했나요? (이유/동기/관련 테켓)
-->
아바타 API의 요청 파라미터로 `OwnerType`을 추가해서, 방 아바타에 대한 요청인지 회원 아바타에 대한 요청인지 구분할 수 있도록 개선했습니다.

## 🔗 관련 이슈
<!--
  이슈 번호 및 링크
-->
#124 