### PR TITLE
[chore] 회원 조회에서도 `avatarUrl`을 바로 반환하게 수정

### DIFF
--- a/src/main/kotlin/goodspace/teaming/user/domain/mapper/UserInfoMapper.kt
+++ b/src/main/kotlin/goodspace/teaming/user/domain/mapper/UserInfoMapper.kt
@@ -1,16 +1,19 @@
 package goodspace.teaming.user.domain.mapper
 
+import goodspace.teaming.file.domain.CdnStorageUrlProvider
 import goodspace.teaming.global.entity.user.User
 import goodspace.teaming.user.dto.UserInfoResponseDto
 import org.springframework.stereotype.Component
 
 @Component
-class UserInfoMapper {
+class UserInfoMapper(
+    private val storageUrlProvider: CdnStorageUrlProvider
+) {
     fun map(user: User): UserInfoResponseDto {
         return UserInfoResponseDto(
             email = user.email,
             name = user.name,
-            avatarKey = user.avatarKey,
+            avatarUrl = storageUrlProvider.publicUrl(user.avatarKey, user.avatarVersion),
             avatarVersion = user.avatarVersion
         )
     }

--- a/src/main/kotlin/goodspace/teaming/user/dto/UserInfoResponseDto.kt
+++ b/src/main/kotlin/goodspace/teaming/user/dto/UserInfoResponseDto.kt
@@ -3,6 +3,6 @@ package goodspace.teaming.user.dto
 data class UserInfoResponseDto(
     val email: String,
     val name: String,
-    val avatarKey: String?,
-    val avatarVersion: Int?
+    val avatarUrl: String?,
+    val avatarVersion: Int
 )


### PR DESCRIPTION
## 🔍 개요
<!--
  무엇을 변경했나요?
  왜 변경했나요? (이유/동기/관련 테켓)
-->
회원 조회에서도 `avatarKey` 대신 `avatarUrl`을 반환하도록 개선했습니다.