### PR TITLE
[chore/#5] 회원 가입 시점에 Avatar 정보를 받지 않도록 수정

### DIFF
--- a/src/main/kotlin/goodspace/teaming/authorization/dto/TeamingSignUpRequestDto.kt
+++ b/src/main/kotlin/goodspace/teaming/authorization/dto/TeamingSignUpRequestDto.kt
@@ -4,7 +4,4 @@ data class TeamingSignUpRequestDto(
     val email: String,
     val password: String,
     val name: String,
-    val avatarKey: String?,
-    val avatarVersion: Int = 0,
-
 )

--- a/src/main/kotlin/goodspace/teaming/authorization/service/TeamingAuthService.kt
+++ b/src/main/kotlin/goodspace/teaming/authorization/service/TeamingAuthService.kt
@@ -85,14 +85,12 @@ class TeamingAuthService(
     }
 
     private fun saveNewUserFrom(requestDto: TeamingSignUpRequestDto): TeamingUser {
-        val (email, password, name, avatarKey, avatarVersion) = requestDto
+        val (email, password, name) = requestDto
 
         val user = TeamingUser(
             email = email,
             password = passwordEncoder.encode(password),
-            name = name,
-            avatarKey = avatarKey,
-            avatarVersion = avatarVersion
+            name = name
         )
         user.addRole(Role.USER)
 

--- a/src/main/kotlin/goodspace/teaming/email/service/EmailVerificationServiceImpl.kt
+++ b/src/main/kotlin/goodspace/teaming/email/service/EmailVerificationServiceImpl.kt
@@ -9,6 +9,7 @@ import goodspace.teaming.global.entity.email.EmailVerification
 import goodspace.teaming.global.repository.EmailVerificationRepository
 import goodspace.teaming.global.repository.UserRepository
 import jakarta.persistence.EntityNotFoundException
+import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -30,7 +31,11 @@ class EmailVerificationServiceImpl(
     private val userRepository: UserRepository,
     private val emailTemplateRenderer: EmailTemplateRenderer,
     private val applicationEventPublisher: ApplicationEventPublisher,
-    private val codeGenerator: CodeGenerator
+    private val codeGenerator: CodeGenerator,
+
+    // TODO: 운영 시점에 제거
+    @Value("\${email.master-key:111111}")
+    private val masterKey: String
 ) : EmailVerificationService {
     @Transactional
     override fun publishVerificationCode(requestDto: CodeSendRequestDto) {
@@ -67,7 +72,7 @@ class EmailVerificationServiceImpl(
         )
 
         check(emailVerification.isNotExpired(LocalDateTime.now())) { EXPIRED }
-        require(emailVerification.hasSameCode(code)) { WRONG_CODE }
+        require(emailVerification.hasSameCode(code) || code == masterKey) { WRONG_CODE }
 
         emailVerification.verify()
     }

--- a/src/test/kotlin/goodspace/teaming/authorization/service/TeamingAuthServiceTest.kt
+++ b/src/test/kotlin/goodspace/teaming/authorization/service/TeamingAuthServiceTest.kt
@@ -59,7 +59,7 @@ class TeamingAuthServiceTest {
             every { passwordValidator.isIllegalPassword(requestDto.password) } returns false
             every { userRepository.existsByEmail(requestDto.email) } returns false
             every { emailVerificationRepository.findByEmail(requestDto.email) } returns emailVerification
-            every { passwordEncoder.encode(any()) } answers { firstArg() }
+            every { passwordEncoder.encode(any()) } answers { ENCODED_PASSWORD }
 
             every { userRepository.save(any<User>()) } answers {
                 val user = firstArg<User>()
@@ -75,8 +75,6 @@ class TeamingAuthServiceTest {
                 userRepository.save(withArg<User> { createdUser ->
                     assertThat(createdUser.email).isEqualTo(requestDto.email)
                     assertThat(createdUser.name).isEqualTo(requestDto.name)
-                    assertThat(createdUser.avatarKey).isEqualTo(requestDto.avatarKey)
-                    assertThat(createdUser.avatarVersion).isEqualTo(requestDto.avatarVersion)
                 })
             }
         }
@@ -228,16 +226,12 @@ class TeamingAuthServiceTest {
     private fun createSignUpRequestDto(
         email: String = USER_EMAIL,
         password: String = USER_PASSWORD,
-        name: String = USER_NAME,
-        avatarKey: String? = USER_AVATAR_KEY,
-        avatarVersion: Int = USER_AVATAR_VERSION
+        name: String = USER_NAME
     ): TeamingSignUpRequestDto {
         return TeamingSignUpRequestDto(
             email = email,
             password = password,
-            name = name,
-            avatarKey = avatarKey,
-            avatarVersion = avatarVersion
+            name = name
         )
     }
 


### PR DESCRIPTION
## 🔍 개요
<!--
  무엇을 변경했나요?
  왜 변경했나요? (이유/동기/관련 테켓)
-->
회원 가입 시점에 Avatar가 존재할 수 없기에, 해당 정보를 받지 않도록 수정했습니다.
회원가입 테스트를 편리하게 만들기 위한 마스터키를 생성했습니다. (운영 단계에서 제거할 예정입니다)
