### PR TITLE
[feat/#141] 팀플 성공 시점에 웹소캣으로 이벤트 발행

### DIFF
--- a/src/main/kotlin/goodspace/teaming/chat/dto/RoomSuccessResponseDto.kt
+++ b/src/main/kotlin/goodspace/teaming/chat/dto/RoomSuccessResponseDto.kt
@@ -1,0 +1,5 @@
+package goodspace.teaming.chat.dto
+
+data class RoomSuccessResponseDto(
+    val roomId: Long
+)

--- a/src/main/kotlin/goodspace/teaming/chat/event/RoomSuccessEvent.kt
+++ b/src/main/kotlin/goodspace/teaming/chat/event/RoomSuccessEvent.kt
@@ -1,0 +1,5 @@
+package goodspace.teaming.chat.event
+
+data class RoomSuccessEvent(
+    val roomId: Long
+)

--- a/src/main/kotlin/goodspace/teaming/chat/event/RoomSuccessEventHandler.kt
+++ b/src/main/kotlin/goodspace/teaming/chat/event/RoomSuccessEventHandler.kt
@@ -1,0 +1,20 @@
+package goodspace.teaming.chat.event
+
+import goodspace.teaming.chat.dto.RoomSuccessResponseDto
+import org.springframework.messaging.simp.SimpMessagingTemplate
+import org.springframework.stereotype.Component
+import org.springframework.transaction.event.TransactionPhase
+import org.springframework.transaction.event.TransactionalEventListener
+
+@Component
+class RoomSuccessEventHandler(
+    private val messaging: SimpMessagingTemplate
+) {
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    fun onReadBoundaryUpdated(event: RoomSuccessEvent) {
+        messaging.convertAndSend(
+            "/topic/rooms/${event.roomId}/success",
+            RoomSuccessResponseDto(roomId = event.roomId)
+        )
+    }
+}

--- a/src/main/kotlin/goodspace/teaming/chat/service/RoomServiceImpl.kt
+++ b/src/main/kotlin/goodspace/teaming/chat/service/RoomServiceImpl.kt
@@ -7,6 +7,7 @@ import goodspace.teaming.chat.domain.mapper.RoomMemberMapper
 import goodspace.teaming.chat.domain.mapper.RoomSearchMapper
 import goodspace.teaming.chat.dto.*
 import goodspace.teaming.chat.event.MemberEnteredEvent
+import goodspace.teaming.chat.event.RoomSuccessEvent
 import goodspace.teaming.chat.exception.InviteCodeAllocationFailedException
 import goodspace.teaming.global.entity.room.PaymentStatus
 import goodspace.teaming.global.entity.room.RoomRole
@@ -171,7 +172,7 @@ class RoomServiceImpl(
 
         check(userRoom.roomRole == RoomRole.LEADER) { NOT_LEADER }
 
-        // TODO 환불 이벤트 발생
+        eventPublisher.publishEvent(RoomSuccessEvent(roomId = room.id!!))
 
         room.success = true
     }


### PR DESCRIPTION
## 🔍 개요
<!--
  무엇을 변경했나요?
  왜 변경했나요? (이유/동기/관련 테켓)
-->
팀플 성공을 팀원들이 바로 알 수 있도록 웹소캣으로 데이터를 전달합니다.

## 🔗 관련 이슈
<!--
  이슈 번호 및 링크
-->
#141 