### PR TITLE
[feat/#146] 파일 업로드 API 개선

### DIFF
--- a/src/main/kotlin/goodspace/teaming/file/domain/FileConstants.kt
+++ b/src/main/kotlin/goodspace/teaming/file/domain/FileConstants.kt
@@ -8,5 +8,29 @@ object FileConstants {
     const val MIN_OBJECT_BYTES: Long = 1L
     const val SAFE_NAME_MAX_LENGTH: Int = 120
     val DATE_FMT: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy/MM")
-    val ALLOWED_MIME_PREFIXES = listOf("image/", "video/", "audio/", "application/pdf")
+    val ALLOWED_MIME_PREFIXES = listOf(
+        "image/",
+        "video/",
+        "audio/",
+
+        // 문서
+        "application/pdf",
+        "application/pdf",
+        "application/msword",
+        "application/vnd.ms-excel",
+        "application/vnd.ms-powerpoint",
+        "application/vnd.openxmlformats-officedocument.wordprocessingml.document",  // docx
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",       // xlsx
+        "application/vnd.openxmlformats-officedocument.presentationml.presentation", // pptx
+        "text/plain",
+        "text/csv",
+        "application/json",
+
+        // 압축
+        "application/zip",
+        "application/x-zip-compressed",
+        "application/x-7z-compressed",
+        "application/x-rar-compressed",
+        "application/x-tar",
+    )
 }

--- a/src/main/kotlin/goodspace/teaming/file/domain/FileValidation.kt
+++ b/src/main/kotlin/goodspace/teaming/file/domain/FileValidation.kt
@@ -5,7 +5,7 @@ import org.springframework.stereotype.Component
 
 private const val MSG_NOT_ROOM_MEMBER = "해당 방 소속이 아닙니다."
 private const val MSG_SIZE_TOO_LARGE = "파일 크기가 너무 큽니다."
-private const val MSG_INVALID_OBJECT_SIZE = "객체 크기가 적절하지 않습니다."
+private const val EMPTY_FILE = "빈 파일입니다."
 private const val MSG_UNSUPPORTED_CONTENT_TYPE = "지원하지 않는 Content-Type 입니다."
 
 @Component
@@ -17,11 +17,8 @@ class FileValidation(
     }
 
     fun validateDeclaredSize(size: Long) {
+        require(size > 0) { EMPTY_FILE }
         require(size in FileConstants.MIN_OBJECT_BYTES..(FileConstants.MAX_UPLOAD_SIZE_MB * FileConstants.BYTES_PER_MB)) { MSG_SIZE_TOO_LARGE }
-    }
-
-    fun validateStoredSize(size: Long) {
-        require(size in FileConstants.MIN_OBJECT_BYTES..(FileConstants.MAX_UPLOAD_SIZE_MB * FileConstants.BYTES_PER_MB)) { MSG_INVALID_OBJECT_SIZE }
     }
 
     fun validateAllowedContentType(mime: String) {

--- a/src/main/kotlin/goodspace/teaming/file/service/S3FileUploadService.kt
+++ b/src/main/kotlin/goodspace/teaming/file/service/S3FileUploadService.kt
@@ -36,7 +36,6 @@ class S3FileUploadService(
     private val eventPublisher: ApplicationEventPublisher,
     @Value("\${cloud.aws.uploads.prefix:chat}") private val prefix: String,
 ) : FileUploadService {
-
     @Transactional(readOnly = true)
     override fun intent(
         userId: Long,
@@ -67,7 +66,7 @@ class S3FileUploadService(
         requireKeyBelongsToRoomAndUser(requestDto.key, roomId, userId)
 
         val head = try {
-            s3.head(requestDto.key) // ← 일반 HEAD
+            s3.head(requestDto.key)
         } catch (e: S3Exception) {
             throw IllegalArgumentException(MSG_ORIGINAL_MISSING, e)
         }
@@ -77,8 +76,6 @@ class S3FileUploadService(
 
         val mime = head.contentType() ?: guessContentTypeFromKey(requestDto.key)
         validation.validateAllowedContentType(mime)
-
-        // require(!head.checksumSHA256().isNullOrBlank()) { MSG_CHECKSUM_MISSING } // ← 제거
 
         val storedName = requestDto.key.substringAfterLast('/')
         val file = fileRepository.save(


### PR DESCRIPTION
## 🔍 개요
<!--
  무엇을 변경했나요?
  왜 변경했나요? (이유/동기/관련 테켓)
-->
파일 크기가 0 이하일 때 적절한 예외 메시지를 제공하도록 개선했습니다.
업로드를 지원하는 파일 형식을 늘렸습니다.

## 🔗 관련 이슈
<!--
  이슈 번호 및 링크
-->
#146 

## 📝 참고할 사항
커밋 제목에 잘못된 이슈 번호를 붙였습니다.
