### PR TITLE
[fix/#148] Assignment 엔티티 Cascade 문제 해결

### DIFF
--- a/src/main/kotlin/goodspace/teaming/assignment/domain/mapper/AssignedMemberMapper.kt
+++ b/src/main/kotlin/goodspace/teaming/assignment/domain/mapper/AssignedMemberMapper.kt
@@ -3,6 +3,7 @@ package goodspace.teaming.assignment.domain.mapper
 import goodspace.teaming.global.entity.aissgnment.AssignedMember
 import goodspace.teaming.global.entity.aissgnment.Assignment
 import goodspace.teaming.global.entity.room.Room
+import goodspace.teaming.global.entity.room.UserRoom
 import goodspace.teaming.global.entity.user.User
 import org.springframework.stereotype.Component
 
@@ -10,12 +11,15 @@ private const val NOT_MEMBER = "해당 티밍룸에 소속되어 있지 않습�
 
 @Component
 class AssignedMemberMapper {
-    fun map(user: User, room: Room, assignment: Assignment): AssignedMember {
+    fun map(userRoom: UserRoom, assignment: Assignment): AssignedMember {
+        val user = userRoom.user
+        val room = userRoom.room
+
         val memberSet = room.memberSet()
         require(memberSet.contains(user)) { NOT_MEMBER }
 
         return AssignedMember(
-            user = user,
+            userRoom = userRoom,
             assignment = assignment
         )
     }

--- a/src/main/kotlin/goodspace/teaming/global/entity/aissgnment/AssignedMember.kt
+++ b/src/main/kotlin/goodspace/teaming/global/entity/aissgnment/AssignedMember.kt
@@ -1,6 +1,7 @@
 package goodspace.teaming.global.entity.aissgnment
 
 import goodspace.teaming.global.entity.BaseEntity
+import goodspace.teaming.global.entity.room.UserRoom
 import goodspace.teaming.global.entity.user.User
 import jakarta.persistence.*
 import jakarta.persistence.FetchType.*
@@ -15,12 +16,15 @@ import org.hibernate.annotations.SQLRestriction
 class AssignedMember(
     @ManyToOne(fetch = LAZY)
     @JoinColumn(nullable = false)
-    val user: User,
+    val userRoom: UserRoom,
 
     @ManyToOne(fetch = LAZY)
     @JoinColumn(nullable = false)
     val assignment: Assignment,
 ) : BaseEntity() {
+    val user: User
+        get() = userRoom.user
+
     @Id
     @GeneratedValue(strategy = IDENTITY)
     val id: Long? = null

--- a/src/main/kotlin/goodspace/teaming/global/entity/email/EmailVerification.kt
+++ b/src/main/kotlin/goodspace/teaming/global/entity/email/EmailVerification.kt
@@ -14,7 +14,7 @@ import java.time.LocalDateTime
 @SQLRestriction("deleted = false")
 class EmailVerification(
     /** 인증 대상 이메일 */
-    @Column(unique = true, nullable = false, length = 254)
+    @Column(nullable = false, length = 254)
     val email: String,
 
     /** 발급된 인증 코드 */

--- a/src/main/kotlin/goodspace/teaming/global/entity/room/UserRoom.kt
+++ b/src/main/kotlin/goodspace/teaming/global/entity/room/UserRoom.kt
@@ -1,6 +1,7 @@
 package goodspace.teaming.global.entity.room
 
 import goodspace.teaming.global.entity.BaseEntity
+import goodspace.teaming.global.entity.aissgnment.AssignedMember
 import goodspace.teaming.global.entity.user.User
 import jakarta.persistence.*
 import jakarta.persistence.EnumType.*
@@ -33,4 +34,7 @@ class UserRoom(
     @Id
     @GeneratedValue(strategy = IDENTITY)
     val id: Long? = null
+
+    @OneToMany(mappedBy = "userRoom", cascade = [CascadeType.ALL], orphanRemoval = true)
+    val assignedMembers: MutableList<AssignedMember> = mutableListOf()
 }

--- a/src/main/kotlin/goodspace/teaming/global/entity/user/OAuthUser.kt
+++ b/src/main/kotlin/goodspace/teaming/global/entity/user/OAuthUser.kt
@@ -6,8 +6,8 @@ import org.hibernate.annotations.SQLDelete
 
 @Entity
 @SQLDelete(
-    sql = "UPDATE teaming_user " +
-            "SET password = CONCAT('DELETED_', password) " +
+    sql = "UPDATE oauth_user " +
+            "SET identifier = CONCAT('DELETED_', identifier) " +
             "WHERE id = ?"
 )
 class OAuthUser(

--- a/src/main/kotlin/goodspace/teaming/global/entity/user/User.kt
+++ b/src/main/kotlin/goodspace/teaming/global/entity/user/User.kt
@@ -2,15 +2,13 @@ package goodspace.teaming.global.entity.user
 
 import goodspace.teaming.gifticon.Entity.Gifticon
 import goodspace.teaming.global.entity.BaseEntity
-import goodspace.teaming.global.entity.aissgnment.AssignedMember
-import goodspace.teaming.global.entity.aissgnment.Assignment
 import goodspace.teaming.global.entity.room.UserRoom
 import goodspace.teaming.global.security.RefreshToken
 import jakarta.persistence.*
-import jakarta.persistence.CascadeType.*
-import jakarta.persistence.EnumType.*
-import jakarta.persistence.FetchType.*
-import jakarta.persistence.GenerationType.*
+import jakarta.persistence.CascadeType.ALL
+import jakarta.persistence.EnumType.STRING
+import jakarta.persistence.FetchType.LAZY
+import jakarta.persistence.GenerationType.IDENTITY
 import org.hibernate.annotations.SQLDelete
 import org.hibernate.annotations.SQLRestriction
 
@@ -47,12 +45,6 @@ abstract class User(
 
     @OneToMany(mappedBy = "user", fetch = LAZY, cascade = [ALL], orphanRemoval = true)
     val userRooms = mutableListOf<UserRoom>()
-
-    @OneToMany(mappedBy = "user", fetch = LAZY, cascade = [ALL], orphanRemoval = true)
-    val assignedMembers = mutableListOf<AssignedMember>()
-
-    val assignments: List<Assignment>
-        get() = assignedMembers.map { it.assignment }
 
     var token: String? = refreshToken.tokenValue
         set(value) {

--- a/src/main/kotlin/goodspace/teaming/global/entity/user/User.kt
+++ b/src/main/kotlin/goodspace/teaming/global/entity/user/User.kt
@@ -18,7 +18,7 @@ import org.hibernate.annotations.SQLRestriction
 @SQLDelete(sql = "UPDATE `user` SET deleted = true, deleted_at = NOW() WHERE id = ?")
 @SQLRestriction("deleted = false")
 abstract class User(
-    @Column(nullable = false, unique = true)
+    @Column(nullable = false)
     var email: String,
 
     @Column(nullable = false)

--- a/src/test/kotlin/goodspace/teaming/util/CreateUtil.kt
+++ b/src/test/kotlin/goodspace/teaming/util/CreateUtil.kt
@@ -118,12 +118,12 @@ fun createAssignment(
 }
 
 fun createAssignedMember(
-    user: User,
+    userRoom: UserRoom,
     assignment: Assignment,
     id: Long? = ASSIGNED_MEMBER_ID
 ): AssignedMember {
     val assignedMember = AssignedMember(
-        user = user,
+        userRoom = userRoom,
         assignment = assignment
     )
     ReflectionTestUtils.setField(assignedMember, "id", id)


### PR DESCRIPTION
## 🔍 개요
<!--
  무엇을 변경했나요?
  왜 변경했나요? (이유/동기/관련 테켓)
-->
엔티티 연관관계를 수정해 Assignment에 대한 Cascade 문제를 해결했습니다.
DB를 직접 마이그레이션 하기 위해, 엔티티 단에 적용된 UNIQUE 제약조건을 제거했습니다.

## 🔗 관련 이슈
<!--
  이슈 번호 및 링크
-->
#148 
#151 