### PR TITLE
[feat/#149] 비밀번호 변경 시 이메일 인증이 필요하도록 변경

### DIFF
--- a/src/main/kotlin/goodspace/teaming/user/dto/UpdatePasswordRequestDto.kt
+++ b/src/main/kotlin/goodspace/teaming/user/dto/UpdatePasswordRequestDto.kt
@@ -2,5 +2,6 @@ package goodspace.teaming.user.dto
 
 data class UpdatePasswordRequestDto(
     val currentPassword: String,
-    val newPassword: String
+    val newPassword: String,
+    val email: String
 )

--- a/src/main/kotlin/goodspace/teaming/user/service/UserServiceImpl.kt
+++ b/src/main/kotlin/goodspace/teaming/user/service/UserServiceImpl.kt
@@ -48,6 +48,8 @@ class UserServiceImpl(
 
     @Transactional
     override fun updatePassword(userId: Long, requestDto: UpdatePasswordRequestDto) {
+        checkEmailVerification(requestDto.email)
+
         val user = findTeamingUser(userId)
         val actualCurrentPassword = user.password
         val expectedCurrentPassword = passwordEncoder.encode(requestDto.currentPassword)


### PR DESCRIPTION
## 🔍 개요
<!--
  무엇을 변경했나요?
  왜 변경했나요? (이유/동기/관련 테켓)
-->
보안 증진을 위해 비밀번호 변경 시 이메일 인증을 선행해야 하도록 수정했습니다.

## 🔗 관련 이슈
<!--
  이슈 번호 및 링크
-->
#149 
