### PR TITLE
[refactor/#161] 예외 메시지를 전역적으로 관리

### DIFF
--- a/src/main/kotlin/goodspace/teaming/assignment/service/AssignmentServiceImpl.kt
+++ b/src/main/kotlin/goodspace/teaming/assignment/service/AssignmentServiceImpl.kt
@@ -18,23 +18,13 @@ import goodspace.teaming.global.entity.room.Room
 import goodspace.teaming.global.entity.room.RoomRole
 import goodspace.teaming.global.entity.room.UserRoom
 import goodspace.teaming.global.entity.user.User
+import goodspace.teaming.global.exception.*
 import goodspace.teaming.global.repository.FileRepository
 import goodspace.teaming.global.repository.UserRepository
 import goodspace.teaming.global.repository.UserRoomRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.Instant
-
-private const val USER_ROOM_NOT_FOUND = "해당 티밍룸에 소속되어있지 않습니다."
-private const val USER_NOT_FOUND = "해당 회원을 조회할 수 없습니다."
-private const val INACCESSIBLE = "해당 티밍룸에 접근할 수 없습니다."
-private const val MEMBER_FOR_ASSIGNED_NOT_FOUND = "과제를 할당할 회원을 조회할 수 없습니다."
-private const val FILE_NOT_FOUND = "파일을 찾을 수 없습니다."
-private const val NOT_LEADER = "팀장이 아닙니다."
-private const val NOT_ASSIGNED = "해당 과제에 할당되지 않았습니다."
-private const val ASSIGNMENT_NOT_FOUND = "과제를 찾을 수 없습니다."
-private const val CANCELED_ASSIGNMENT = "취소된 과제입니다."
-private const val COMPLETE_ASSIGNMENT = "이미 완료된 과제입니다."
 
 @Service
 class AssignmentServiceImpl(
@@ -142,7 +132,7 @@ class AssignmentServiceImpl(
 
     private fun findUserRoom(userId: Long, roomId: Long): UserRoom {
         return userRoomRepository.findByRoomIdAndUserId(roomId, userId)
-            ?: throw IllegalArgumentException(USER_ROOM_NOT_FOUND)
+            ?: throw IllegalArgumentException(NOT_MEMBER_OF_ROOM)
     }
 
     private fun findUser(userId: Long): User {
@@ -151,7 +141,7 @@ class AssignmentServiceImpl(
     }
 
     private fun assertPayment(userRoom: UserRoom) {
-        check(userRoom.paymentStatus != NOT_PAID) { INACCESSIBLE }
+        check(userRoom.paymentStatus != NOT_PAID) { ROOM_INACCESSIBLE }
     }
 
     private fun assertLeader(userRoom: UserRoom) {
@@ -172,7 +162,7 @@ class AssignmentServiceImpl(
 
     private fun List<Long>.toUserRoomSet(room: Room): Set<UserRoom> {
         return this.map { userRepository.findById(it)
-                .orElseThrow { IllegalArgumentException(MEMBER_FOR_ASSIGNED_NOT_FOUND) }
+                .orElseThrow { IllegalArgumentException(MEMBER_TO_ASSIGN_NOT_FOUND) }
             }
             .flatMap { it.userRooms }
             .filter { it.room == room }

--- a/src/main/kotlin/goodspace/teaming/authorization/service/TeamingAuthService.kt
+++ b/src/main/kotlin/goodspace/teaming/authorization/service/TeamingAuthService.kt
@@ -4,6 +4,10 @@ import goodspace.teaming.authorization.dto.TeamingSignInRequestDto
 import goodspace.teaming.authorization.dto.TeamingSignUpRequestDto
 import goodspace.teaming.global.entity.user.Role
 import goodspace.teaming.global.entity.user.TeamingUser
+import goodspace.teaming.global.exception.ALREADY_EXISTS_EMAIL
+import goodspace.teaming.global.exception.ILLEGAL_PASSWORD
+import goodspace.teaming.global.exception.NOT_VERIFIED_EMAIL
+import goodspace.teaming.global.exception.USER_NOT_FOUND
 import goodspace.teaming.global.password.PasswordValidator
 import goodspace.teaming.global.repository.EmailVerificationRepository
 import goodspace.teaming.global.repository.UserRepository
@@ -13,11 +17,6 @@ import goodspace.teaming.global.security.TokenType
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-
-private const val USER_NOT_FOUND = "회원을 조회할 수 없습니다."
-private const val ILLEGAL_PASSWORD = "부적절한 비밀번호입니다."
-private const val EXISTS_EMAIL = "이미 사용중인 이메일입니다."
-private const val NOT_VERIFIED_EMAIL = "인증되지 않은 이메일입니다."
 
 @Service
 class TeamingAuthService(
@@ -74,7 +73,7 @@ class TeamingAuthService(
     }
 
     private fun assertEmail(email: String) {
-        require(!userRepository.existsByEmail(email)) { EXISTS_EMAIL }
+        require(!userRepository.existsByEmail(email)) { ALREADY_EXISTS_EMAIL }
 
         val emailVerification = emailVerificationRepository.findByEmail(email)
             ?: throw IllegalStateException(NOT_VERIFIED_EMAIL)

--- a/src/main/kotlin/goodspace/teaming/chat/service/MessageServiceImpl.kt
+++ b/src/main/kotlin/goodspace/teaming/chat/service/MessageServiceImpl.kt
@@ -13,6 +13,8 @@ import goodspace.teaming.global.entity.file.File
 import goodspace.teaming.global.entity.file.FileType
 import goodspace.teaming.global.entity.room.*
 import goodspace.teaming.global.entity.user.User
+import goodspace.teaming.global.exception.INCLUDE_NOT_EXIST_FILE
+import goodspace.teaming.global.exception.NOT_PAID
 import goodspace.teaming.global.repository.FileRepository
 import goodspace.teaming.global.repository.MessageRepository
 import goodspace.teaming.global.repository.UserRoomRepository
@@ -24,10 +26,6 @@ import org.springframework.data.domain.Slice
 import org.springframework.data.domain.Sort
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-
-private const val ROOM_NOT_FOUND = "티밍룸을 조회할 수 없습니다."
-private const val NOT_PAID = "결제되지 않아 티밍룸에 엑세스할 수 없습니다."
-private const val NOT_EXIST_FILE = "존재하지 않는 파일이 포함되어 있습니다."
 
 @Service
 class MessageServiceImpl(
@@ -103,7 +101,7 @@ class MessageServiceImpl(
 
     private fun findUserRoom(userId: Long, roomId: Long): UserRoom {
         return userRoomRepository.findByRoomIdAndUserId(roomId, userId)
-            ?: throw IllegalArgumentException(ROOM_NOT_FOUND)
+            ?: throw IllegalArgumentException(goodspace.teaming.global.exception.ROOM_NOT_FOUND)
     }
 
     private fun getExistsOrCreate(user: User, room: Room, requestDto: ChatSendRequestDto): Message {
@@ -139,7 +137,7 @@ class MessageServiceImpl(
     }
 
     private fun validateFiles(files: List<File>, fileIds: List<Long>, room: Room, user: User) {
-        require(files.size == fileIds.size) { NOT_EXIST_FILE }
+        require(files.size == fileIds.size) { INCLUDE_NOT_EXIST_FILE }
 
         files.forEach { file ->
             require(file.room.id == room.id && file.uploaderId == user.id) { "이 방/사용자의 파일이 아닙니다." }

--- a/src/main/kotlin/goodspace/teaming/chat/service/RoomAccessService.kt
+++ b/src/main/kotlin/goodspace/teaming/chat/service/RoomAccessService.kt
@@ -1,15 +1,15 @@
 package goodspace.teaming.chat.service
 
+import goodspace.teaming.global.exception.NOT_MEMBER_OF_ROOM
 import goodspace.teaming.global.repository.UserRoomRepository
 import org.springframework.stereotype.Service
 
-private const val USER_ROOM_NOT_FOUND = "해당 방에 소속되지 않았습니다."
 
 @Service
 class RoomAccessService(
     private val userRoomRepository: UserRoomRepository
 ) : RoomAccessAuthorizer {
     override fun assertMemberOf(roomId: Long, userId: Long) {
-        require(userRoomRepository.existsByRoomIdAndUserId(roomId, userId)) { USER_ROOM_NOT_FOUND }
+        require(userRoomRepository.existsByRoomIdAndUserId(roomId, userId)) { NOT_MEMBER_OF_ROOM }
     }
 }

--- a/src/main/kotlin/goodspace/teaming/chat/service/UnreadServiceImpl.kt
+++ b/src/main/kotlin/goodspace/teaming/chat/service/UnreadServiceImpl.kt
@@ -5,16 +5,14 @@ import goodspace.teaming.chat.dto.RoomUnreadCountResponseDto
 import goodspace.teaming.chat.event.ReadBoundaryUpdatedEvent
 import goodspace.teaming.global.entity.room.PaymentStatus
 import goodspace.teaming.global.entity.room.UserRoom
+import goodspace.teaming.global.exception.NOT_PAID
+import goodspace.teaming.global.exception.ROOM_NOT_FOUND
 import goodspace.teaming.global.repository.MessageRepository
 import goodspace.teaming.global.repository.UserRoomRepository
 import org.springframework.context.ApplicationEventPublisher
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.lang.IllegalArgumentException
-
-private const val NOT_PAID = "결제되지 않아 티밍룸에 엑세스할 수 없습니다."
-
-private const val ROOM_NOT_FOUND = "티밍룸을 조회할 수 없습니다."
 
 @Service
 class UnreadServiceImpl(

--- a/src/main/kotlin/goodspace/teaming/email/service/EmailVerificationServiceImpl.kt
+++ b/src/main/kotlin/goodspace/teaming/email/service/EmailVerificationServiceImpl.kt
@@ -6,6 +6,7 @@ import goodspace.teaming.email.dto.CodeSendRequestDto
 import goodspace.teaming.email.dto.EmailVerifyRequestDto
 import goodspace.teaming.email.event.EmailSendRequestEvent
 import goodspace.teaming.global.entity.email.EmailVerification
+import goodspace.teaming.global.exception.*
 import goodspace.teaming.global.repository.EmailVerificationRepository
 import goodspace.teaming.global.repository.UserRepository
 import jakarta.persistence.EntityNotFoundException
@@ -16,11 +17,6 @@ import java.time.LocalDateTime
 
 private const val MAIL_SUBJECT = "[Teaming] 이메일 인증 코드를 확인해주세요"
 
-private const val EMAIL_NOT_FOUND = "이메일을 찾을 수 없습니다."
-private const val EXPIRED = "이메일 인증이 만료되었습니다."
-private const val WRONG_CODE = "코드가 올바르지 않습니다."
-private const val NOT_EXISTS_EMAIL = "존재하지 않는 이메일입니다."
-private const val DUPLICATE_EMAIL = "이미 존재하는 이메일입니다."
 private const val CODE_LENGTH = 6
 private const val EXPIRE_MINUTES = 5
 
@@ -64,7 +60,7 @@ class EmailVerificationServiceImpl(
         val emailVerification = emailVerificationRepository.findByEmail(email)
             ?: throw EntityNotFoundException(EMAIL_NOT_FOUND)
 
-        check(emailVerification.isNotExpired(LocalDateTime.now())) { EXPIRED }
+        check(emailVerification.isNotExpired(LocalDateTime.now())) { EXPIRED_EMAIL_VERIFICATION }
         check(requestDto.code == emailVerification.code) { WRONG_CODE }
 
         emailVerification.verify()

--- a/src/main/kotlin/goodspace/teaming/file/service/S3FileDownloadService.kt
+++ b/src/main/kotlin/goodspace/teaming/file/service/S3FileDownloadService.kt
@@ -2,15 +2,14 @@ package goodspace.teaming.file.service
 
 import goodspace.teaming.file.domain.S3PresignSupport
 import goodspace.teaming.file.dto.DownloadUrlResponseDto
+import goodspace.teaming.global.exception.FILE_NOT_FOUND
+import goodspace.teaming.global.exception.NOT_MEMBER_OF_ROOM
+import goodspace.teaming.global.exception.ORIGINAL_FILE_MISSING
 import goodspace.teaming.global.repository.FileRepository
 import goodspace.teaming.global.repository.UserRoomRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import software.amazon.awssdk.services.s3.model.S3Exception
-
-private const val MSG_FILE_NOT_FOUND = "파일을 찾을 수 없습니다."
-private const val MSG_NOT_ROOM_MEMBER = "해당 방 소속이 아닙니다."
-private const val MSG_ORIGINAL_MISSING = "원본 파일이 존재하지 않습니다."
 
 @Service
 class S3FileDownloadService(
@@ -22,14 +21,14 @@ class S3FileDownloadService(
     @Transactional(readOnly = true)
     override fun issueDownloadUrl(userId: Long, fileId: Long): DownloadUrlResponseDto {
         val file = fileRepository.findById(fileId)
-            .orElseThrow { IllegalArgumentException(MSG_FILE_NOT_FOUND) }
+            .orElseThrow { IllegalArgumentException(FILE_NOT_FOUND) }
 
-        require(userRoomRepository.existsByRoomIdAndUserId(file.room.id!!, userId)) { MSG_NOT_ROOM_MEMBER }
+        require(userRoomRepository.existsByRoomIdAndUserId(file.room.id!!, userId)) { NOT_MEMBER_OF_ROOM }
 
         val head = try {
             s3.head(file.storageKey) // ← 변경: 일반 HEAD
         } catch (e: S3Exception) {
-            throw IllegalArgumentException(MSG_ORIGINAL_MISSING, e)
+            throw IllegalArgumentException(ORIGINAL_FILE_MISSING, e)
         }
 
         val filename = file.name.ifBlank { file.storageKey.substringAfterLast('/') }

--- a/src/main/kotlin/goodspace/teaming/global/exception/ErrorMessages.kt
+++ b/src/main/kotlin/goodspace/teaming/global/exception/ErrorMessages.kt
@@ -1,0 +1,47 @@
+package goodspace.teaming.global.exception
+
+// User
+const val USER_NOT_FOUND = "해당 회원을 조회할 수 없습니다."
+const val ILLEGAL_TOKEN = "부적절한 토큰입니다."
+const val EXPIRED_REFRESH_TOKEN = "만료된 리프레쉬 토큰입니다."
+const val OAUTH_USER_CANNOT_CHANGE_PASSWORD = "소셜 회원은 이메일을 변경할 수 없습니다."
+const val WRONG_PASSWORD = "비밀번호가 올바르지 않습니다."
+const val ILLEGAL_PASSWORD = "부적절한 비밀번호입니다."
+
+// Room
+const val ROOM_NOT_FOUND = "티밍룸을 조회할 수 없습니다."
+const val NOT_PAID = "결제되지 않아 티밍룸에 엑세스할 수 없습니다."
+const val ALREADY_MEMBER_OF_ROOM = "이미 해당 티밍룸에 소속되어 있습니다."
+const val NOT_MEMBER_OF_ROOM = "해당 티밍룸에 소속되어있지 않습니다."
+const val NOT_LEADER = "팀장이 아닙니다."
+const val ROOM_INACCESSIBLE = "해당 티밍룸에 접근할 수 없습니다."
+const val WRONG_INVITE_CODE = "부적절한 초대 코드입니다."
+const val CANNOT_LEAVE_BEFORE_SUCCESS = "팀플에 성공하기 전까진 나갈 수 없습니다."
+const val ILLEGAL_ROOM_TITLE = "부적절한 티밍룸 제목입니다."
+
+// Assignment
+const val ASSIGNMENT_NOT_FOUND = "과제를 찾을 수 없습니다."
+const val MEMBER_TO_ASSIGN_NOT_FOUND = "과제를 할당할 회원을 조회할 수 없습니다."
+const val NOT_ASSIGNED = "해당 과제에 할당되지 않았습니다."
+const val CANCELED_ASSIGNMENT = "취소된 과제입니다."
+const val COMPLETE_ASSIGNMENT = "이미 완료된 과제입니다."
+
+// Email
+const val EMAIL_NOT_FOUND = "이메일을 찾을 수 없습니다."
+const val NOT_EXISTS_EMAIL = "존재하지 않는 이메일입니다."
+const val ALREADY_EXISTS_EMAIL = "이미 사용 중인 이메일입니다."
+const val EXPIRED_EMAIL_VERIFICATION = "이메일 인증이 만료되었습니다."
+const val NOT_VERIFIED_EMAIL = "인증되지 않은 이메일입니다."
+const val DUPLICATE_EMAIL = "이미 존재하는 이메일입니다."
+const val WRONG_CODE = "코드가 올바르지 않습니다."
+
+// File & S3
+const val FILE_NOT_FOUND = "파일을 찾을 수 없습니다."
+const val INCLUDE_NOT_EXIST_FILE = "존재하지 않는 파일이 포함되어 있습니다."
+const val IMAGE_TOO_LARGE = "이미지 크기가 너무 큽니다."
+const val UNSUPPORTED_IMAGE_TYPE = "지원하지 않는 이미지 형식입니다."
+const val INVALID_UPLOAD_KEY = "업로드 키가 올바르지 않습니다."
+const val S3_OBJECT_NOT_FOUND = "S3에 저장된 객체를 찾을 수 없습니다."
+const val ORIGINAL_FILE_MISSING = "원본 파일이 존재하지 않습니다."
+const val INVALID_SIZE = "파일 크기가 적절하지 않습니다."
+const val INVALID_KEY_SCOPE = "Key에 방 정보와 회원 정보가 누락되었습니다."

--- a/src/main/kotlin/goodspace/teaming/user/service/TokenManagementServiceImpl.kt
+++ b/src/main/kotlin/goodspace/teaming/user/service/TokenManagementServiceImpl.kt
@@ -3,15 +3,14 @@ package goodspace.teaming.user.service
 import goodspace.teaming.authorization.dto.AccessTokenReissueRequestDto
 import goodspace.teaming.authorization.dto.AccessTokenResponseDto
 import goodspace.teaming.global.entity.user.User
+import goodspace.teaming.global.exception.EXPIRED_REFRESH_TOKEN
+import goodspace.teaming.global.exception.ILLEGAL_TOKEN
+import goodspace.teaming.global.exception.USER_NOT_FOUND
 import goodspace.teaming.global.repository.UserRepository
 import goodspace.teaming.global.security.TokenProvider
 import goodspace.teaming.global.security.TokenType
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-
-private const val USER_NOT_FOUND = "회원을 조회할 수 없습니다."
-private const val ILLEGAL_TOKEN = "부적절한 토큰입니다."
-private const val EXPIRED_REFRESH_TOKEN = "만료된 리프레쉬 토큰입니다."
 
 @Service
 class TokenManagementServiceImpl(

--- a/src/main/kotlin/goodspace/teaming/user/service/UserServiceImpl.kt
+++ b/src/main/kotlin/goodspace/teaming/user/service/UserServiceImpl.kt
@@ -3,6 +3,7 @@ package goodspace.teaming.user.service
 import goodspace.teaming.global.entity.user.TeamingUser
 import goodspace.teaming.global.entity.user.User
 import goodspace.teaming.global.entity.user.UserType
+import goodspace.teaming.global.exception.*
 import goodspace.teaming.global.password.PasswordValidator
 import goodspace.teaming.global.repository.EmailVerificationRepository
 import goodspace.teaming.global.repository.UserRepository
@@ -11,13 +12,6 @@ import goodspace.teaming.user.dto.*
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
-
-private const val USER_NOT_FOUND = "회원을 조회할 수 없습니다."
-private const val ILLEGAL_USER_TYPE = "소셜 회원은 이메일을 변경할 수 없습니다."
-private const val EMAIL_ALREADY_EXISTS = "이미 사용 중인 이메일입니다."
-private const val EMAIL_NOT_VERIFIED = "인증되지 않은 이메일입니다."
-private const val WRONG_PASSWORD = "비밀번호가 올바르지 않습니다."
-private const val ILLEGAL_PASSWORD = "부적절한 비밀번호입니다."
 
 @Service
 class UserServiceImpl(
@@ -39,7 +33,7 @@ class UserServiceImpl(
         val user = findUser(userId)
         val email = requestDto.email
 
-        checkUserType(user)
+        checkUserTypeToChangePassword(user)
         checkEmailAlreadyExists(email)
         checkEmailVerification(email)
 
@@ -84,19 +78,19 @@ class UserServiceImpl(
             ?: throw IllegalArgumentException(USER_NOT_FOUND)
     }
 
-    private fun checkUserType(user: User) {
-        check(user.type == UserType.TEAMING) { ILLEGAL_USER_TYPE }
+    private fun checkUserTypeToChangePassword(user: User) {
+        check(user.type == UserType.TEAMING) { OAUTH_USER_CANNOT_CHANGE_PASSWORD }
     }
 
     private fun checkEmailAlreadyExists(email: String) {
-        require(!userRepository.existsByEmail(email)) { EMAIL_ALREADY_EXISTS }
+        require(!userRepository.existsByEmail(email)) { ALREADY_EXISTS_EMAIL }
     }
 
     private fun checkEmailVerification(email: String) {
         val emailVerification = emailVerificationRepository.findByEmail(email)
-            ?: throw IllegalStateException(EMAIL_NOT_VERIFIED)
+            ?: throw IllegalStateException(NOT_VERIFIED_EMAIL)
 
-        check(emailVerification.verified) { EMAIL_NOT_VERIFIED }
+        check(emailVerification.verified) { NOT_VERIFIED_EMAIL }
 
         emailVerificationRepository.delete(emailVerification)
     }

--- a/src/test/kotlin/goodspace/teaming/assignment/service/AssignmentServiceTest.kt
+++ b/src/test/kotlin/goodspace/teaming/assignment/service/AssignmentServiceTest.kt
@@ -14,6 +14,7 @@ import goodspace.teaming.global.entity.aissgnment.AssignmentStatus
 import goodspace.teaming.global.entity.room.*
 import goodspace.teaming.global.entity.user.TeamingUser
 import goodspace.teaming.global.entity.user.User
+import goodspace.teaming.global.exception.CANCELED_ASSIGNMENT
 import goodspace.teaming.global.repository.FileRepository
 import goodspace.teaming.global.repository.UserRepository
 import goodspace.teaming.global.repository.UserRoomRepository
@@ -342,7 +343,7 @@ class AssignmentServiceTest {
             // when & then
             assertThatThrownBy { assignmentService.submit(member.id!!, room.id!!, requestDto) }
                 .isInstanceOf(IllegalStateException::class.java)
-                .hasMessage("취소된 과제입니다.")
+                .hasMessage(CANCELED_ASSIGNMENT)
         }
 
         @Test

--- a/src/test/kotlin/goodspace/teaming/authorization/service/TeamingAuthServiceTest.kt
+++ b/src/test/kotlin/goodspace/teaming/authorization/service/TeamingAuthServiceTest.kt
@@ -4,6 +4,8 @@ import goodspace.teaming.authorization.dto.TeamingSignInRequestDto
 import goodspace.teaming.authorization.dto.TeamingSignUpRequestDto
 import goodspace.teaming.fixture.*
 import goodspace.teaming.global.entity.user.User
+import goodspace.teaming.global.exception.ALREADY_EXISTS_EMAIL
+import goodspace.teaming.global.exception.NOT_VERIFIED_EMAIL
 import goodspace.teaming.global.password.PasswordValidator
 import goodspace.teaming.global.repository.EmailVerificationRepository
 import goodspace.teaming.global.repository.UserRepository
@@ -129,7 +131,7 @@ class TeamingAuthServiceTest {
             // when & then
             assertThatThrownBy { teamingAuthService.signUp(requestDto) }
                 .isInstanceOf(IllegalArgumentException::class.java)
-                .hasMessage("부적절한 비밀번호입니다.")
+                .hasMessage(goodspace.teaming.global.exception.ILLEGAL_PASSWORD)
         }
 
         @Test
@@ -143,7 +145,7 @@ class TeamingAuthServiceTest {
             // when & then
             assertThatThrownBy { teamingAuthService.signUp(requestDto) }
                 .isInstanceOf(IllegalArgumentException::class.java)
-                .hasMessage("이미 사용중인 이메일입니다.")
+                .hasMessage(ALREADY_EXISTS_EMAIL)
         }
 
         @Test
@@ -162,7 +164,7 @@ class TeamingAuthServiceTest {
             // when & then
             assertThatThrownBy { teamingAuthService.signUp(requestDto) }
                 .isInstanceOf(IllegalStateException::class.java)
-                .hasMessage("인증되지 않은 이메일입니다.")
+                .hasMessage(NOT_VERIFIED_EMAIL)
         }
     }
 

--- a/src/test/kotlin/goodspace/teaming/user/service/TokenManagementServiceImplTest.kt
+++ b/src/test/kotlin/goodspace/teaming/user/service/TokenManagementServiceImplTest.kt
@@ -2,6 +2,8 @@ package goodspace.teaming.user.service
 
 import goodspace.teaming.authorization.dto.AccessTokenReissueRequestDto
 import goodspace.teaming.fixture.REFRESH_TOKEN_VALUE
+import goodspace.teaming.global.exception.EXPIRED_REFRESH_TOKEN
+import goodspace.teaming.global.exception.ILLEGAL_TOKEN
 import goodspace.teaming.global.repository.UserRepository
 import goodspace.teaming.global.security.TokenProvider
 import goodspace.teaming.global.security.TokenType
@@ -65,7 +67,7 @@ class TokenManagementServiceImplTest {
             // when & then
             assertThatThrownBy { tokenManagementService.reissueAccessToken(requestDto) }
                 .isInstanceOf(IllegalArgumentException::class.java)
-                .hasMessage("부적절한 토큰입니다.")
+                .hasMessage(ILLEGAL_TOKEN)
         }
 
         @Test
@@ -82,7 +84,7 @@ class TokenManagementServiceImplTest {
             // when & then
             assertThatThrownBy { tokenManagementService.reissueAccessToken(requestDto) }
                 .isInstanceOf(IllegalArgumentException::class.java)
-                .hasMessage("만료된 리프레쉬 토큰입니다.")
+                .hasMessage(EXPIRED_REFRESH_TOKEN)
         }
     }
 

--- a/src/test/kotlin/goodspace/teaming/user/service/UserServiceTest.kt
+++ b/src/test/kotlin/goodspace/teaming/user/service/UserServiceTest.kt
@@ -4,6 +4,8 @@ import goodspace.teaming.fixture.*
 import goodspace.teaming.global.entity.email.EmailVerification
 import goodspace.teaming.global.entity.user.TeamingUser
 import goodspace.teaming.global.entity.user.UserType
+import goodspace.teaming.global.exception.NOT_VERIFIED_EMAIL
+import goodspace.teaming.global.exception.OAUTH_USER_CANNOT_CHANGE_PASSWORD
 import goodspace.teaming.global.password.PasswordValidatorImpl
 import goodspace.teaming.global.repository.EmailVerificationRepository
 import goodspace.teaming.global.repository.UserRepository
@@ -169,7 +171,7 @@ class UserServiceTest {
             // when & then
             assertThatThrownBy { userService.updateEmail(user.id!!, requestDto) }
                 .isInstanceOf(IllegalStateException::class.java)
-                .hasMessage("소셜 회원은 이메일을 변경할 수 없습니다.")
+                .hasMessage(OAUTH_USER_CANNOT_CHANGE_PASSWORD)
         }
     }
 
@@ -284,7 +286,7 @@ class UserServiceTest {
             // when & then
             assertThatThrownBy { userService.updatePassword(user.id!!, requestDto) }
                 .isInstanceOf(IllegalArgumentException::class.java)
-                .hasMessage("비밀번호가 올바르지 않습니다.")
+                .hasMessage(goodspace.teaming.global.exception.WRONG_PASSWORD)
         }
 
         @Test
@@ -310,7 +312,7 @@ class UserServiceTest {
             // when & then
             assertThatThrownBy { userService.updatePassword(user.id!!, requestDto) }
                 .isInstanceOf(IllegalArgumentException::class.java)
-                .hasMessage("부적절한 비밀번호입니다.")
+                .hasMessage(goodspace.teaming.global.exception.ILLEGAL_PASSWORD)
         }
 
         @Test
@@ -328,7 +330,7 @@ class UserServiceTest {
             // when & then
             assertThatThrownBy { userService.updatePassword(user.id!!, requestDto) }
                 .isInstanceOf(IllegalStateException::class.java)
-                .hasMessage("인증되지 않은 이메일입니다.")
+                .hasMessage(NOT_VERIFIED_EMAIL)
         }
     }
 


### PR DESCRIPTION
## 🔍 개요
<!--
  무엇을 변경했나요?
  왜 변경했나요? (이유/동기/관련 테켓)
-->
예외 메시지를 한 파일에서 전역적으로 관리하도록 리팩터링했습니다.

## 🔗 관련 이슈
<!--
  이슈 번호 및 링크
-->
#161 