### PR TITLE
[feat/#170] 방의 준비 상태 조회 API 구현

### DIFF
--- a/src/main/kotlin/goodspace/teaming/chat/controller/ChatRestController.kt
+++ b/src/main/kotlin/goodspace/teaming/chat/controller/ChatRestController.kt
@@ -212,4 +212,20 @@ class ChatRestController(
 
         return ResponseEntity.ok(response)
     }
+
+    @GetMapping("/{roomId}/ready")
+    @Operation(
+        summary = "방 준비 상태 조회",
+        description = "해당 방에 모든 멤버가 참여해 있는지를 조회합니다. 팀플 성공한 방이라면 항상 true를 반환합니다."
+    )
+    fun getIsReady(
+        principal: Principal,
+        @PathVariable roomId: Long
+    ): ResponseEntity<RoomReadyResponseDto> {
+        val userId = principal.getUserId()
+
+        val response = roomService.isReady(userId, roomId)
+
+        return ResponseEntity.ok(response)
+    }
 }

--- a/src/main/kotlin/goodspace/teaming/chat/domain/mapper/RoomInfoMapper.kt
+++ b/src/main/kotlin/goodspace/teaming/chat/domain/mapper/RoomInfoMapper.kt
@@ -12,6 +12,7 @@ class RoomInfoMapper(
     private val lastMessagePreviewMapper: LastMessagePreviewMapper,
     private val roomMemberMapper: RoomMemberMapper,
     private val roomTypeMapper: RoomTypeMapper,
+    private val roomReadyMapper: RoomReadyMapper,
     private val storageUrlProvider: CdnStorageUrlProvider
 )  {
     fun map(userRoom: UserRoom): RoomInfoResponseDto {
@@ -44,7 +45,8 @@ class RoomInfoMapper(
             memberCount = room.memberCount,
             paymentStatus = userRoom.paymentStatus,
             success = room.success,
-            members = members.map { roomMemberMapper.map(it) }
+            members = members.map { roomMemberMapper.map(it) },
+            ready = roomReadyMapper.map(room)
         )
     }
 }

--- a/src/main/kotlin/goodspace/teaming/chat/domain/mapper/RoomReadyMapper.kt
+++ b/src/main/kotlin/goodspace/teaming/chat/domain/mapper/RoomReadyMapper.kt
@@ -1,0 +1,18 @@
+package goodspace.teaming.chat.domain.mapper
+
+import goodspace.teaming.chat.dto.RoomReadyResponseDto
+import goodspace.teaming.global.entity.room.Room
+import org.springframework.stereotype.Component
+
+@Component
+class RoomReadyMapper {
+    fun map(room: Room): RoomReadyResponseDto {
+        return RoomReadyResponseDto(
+            everyMemberEntered = room.everyMemberEntered()
+        )
+    }
+
+    private fun Room.everyMemberEntered(): Boolean {
+        return memberCount == currentMemberCount()
+    }
+}

--- a/src/main/kotlin/goodspace/teaming/chat/dto/RoomInfoResponseDto.kt
+++ b/src/main/kotlin/goodspace/teaming/chat/dto/RoomInfoResponseDto.kt
@@ -15,5 +15,6 @@ data class RoomInfoResponseDto(
     val memberCount: Int,
     val paymentStatus: PaymentStatus,
     val success: Boolean,
-    val members: List<RoomMemberResponseDto>
+    val members: List<RoomMemberResponseDto>,
+    val ready: RoomReadyResponseDto
 )

--- a/src/main/kotlin/goodspace/teaming/chat/dto/RoomReadyResponseDto.kt
+++ b/src/main/kotlin/goodspace/teaming/chat/dto/RoomReadyResponseDto.kt
@@ -1,0 +1,5 @@
+package goodspace.teaming.chat.dto
+
+data class RoomReadyResponseDto(
+    val everyMemberEntered: Boolean
+)

--- a/src/main/kotlin/goodspace/teaming/chat/service/RoomService.kt
+++ b/src/main/kotlin/goodspace/teaming/chat/service/RoomService.kt
@@ -41,4 +41,9 @@ interface RoomService {
         userId: Long,
         roomId: Long
     )
+
+    fun isReady(
+        userId: Long,
+        roomId: Long
+    ): RoomReadyResponseDto
 }

--- a/src/test/kotlin/goodspace/teaming/chat/domain/mapper/RoomInfoMapperTest.kt
+++ b/src/test/kotlin/goodspace/teaming/chat/domain/mapper/RoomInfoMapperTest.kt
@@ -37,6 +37,7 @@ class RoomInfoMapperTest {
     private lateinit var lastMessagePreviewMapper: LastMessagePreviewMapper
     private lateinit var roomMemberMapper: RoomMemberMapper
     private lateinit var roomTypeMapper: RoomTypeMapper
+    private lateinit var roomReadyMapper: RoomReadyMapper
     private lateinit var storageUrlProvider: CdnStorageUrlProvider
 
     private lateinit var roomInfoMapper: RoomInfoMapper
@@ -47,12 +48,14 @@ class RoomInfoMapperTest {
         lastMessagePreviewMapper = mockk(relaxed = true)
         roomMemberMapper = mockk(relaxed = true)
         roomTypeMapper = mockk(relaxed = true)
+        roomReadyMapper = mockk(relaxed = true)
         storageUrlProvider = mockk(relaxed = true)
         roomInfoMapper = RoomInfoMapper(
             messageRepository,
             lastMessagePreviewMapper,
             roomMemberMapper,
             roomTypeMapper,
+            roomReadyMapper,
             storageUrlProvider
         )
     }

--- a/src/test/kotlin/goodspace/teaming/chat/domain/mapper/RoomReadyMapperTest.kt
+++ b/src/test/kotlin/goodspace/teaming/chat/domain/mapper/RoomReadyMapperTest.kt
@@ -1,0 +1,44 @@
+package goodspace.teaming.chat.domain.mapper
+
+import goodspace.teaming.global.entity.room.Room
+import io.mockk.every
+import io.mockk.mockk
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+
+class RoomReadyMapperTest {
+    private val roomReadyMapper = RoomReadyMapper()
+
+    @Nested
+    inner class `방에 모든 인원이 참여했는지를 확인한다` {
+        @Test
+        fun `모든 인원이 참여했다면 true를 반환한다`() {
+            // given: 5명까지 참여 가능한 방에 5명이 참여한 상태
+            val room = mockk<Room>()
+            every { room.currentMemberCount() } returns 5
+            every { room.memberCount } returns 5
+
+            // when
+            val result = roomReadyMapper.map(room)
+
+            // then
+            assertThat(result.everyMemberEntered).isTrue()
+        }
+
+        @Test
+        fun `모든 인원이 참여하지 않았다면 false를 반환한다`() {
+            // given: 5명까지 참여 가능한 방에 4명이 참여한 상태
+            val room = mockk<Room>()
+            every { room.currentMemberCount() } returns 4
+            every { room.memberCount } returns 5
+
+            // when
+            val result = roomReadyMapper.map(room)
+
+            // then
+            assertThat(result.everyMemberEntered).isFalse()
+        }
+    }
+
+}

--- a/src/test/kotlin/goodspace/teaming/chat/service/RoomServiceTest.kt
+++ b/src/test/kotlin/goodspace/teaming/chat/service/RoomServiceTest.kt
@@ -1,10 +1,7 @@
 package goodspace.teaming.chat.service
 
 import goodspace.teaming.chat.domain.InviteCodeGenerator
-import goodspace.teaming.chat.domain.mapper.RoomInfoMapper
-import goodspace.teaming.chat.domain.mapper.RoomMapper
-import goodspace.teaming.chat.domain.mapper.RoomMemberMapper
-import goodspace.teaming.chat.domain.mapper.RoomSearchMapper
+import goodspace.teaming.chat.domain.mapper.*
 import goodspace.teaming.chat.dto.InviteAcceptRequestDto
 import goodspace.teaming.chat.dto.RoomCreateRequestDto
 import goodspace.teaming.chat.dto.RoomInfoResponseDto
@@ -53,6 +50,7 @@ class RoomServiceTest {
     private val roomInfoMapper: RoomInfoMapper = mockk(relaxed = true)
     private val memberMapper: RoomMemberMapper = mockk(relaxed = true)
     private val roomSearchMapper: RoomSearchMapper = mockk(relaxed = true)
+    private val roomReadyMapper: RoomReadyMapper = mockk(relaxed = true)
     private val inviteCodeGenerator: InviteCodeGenerator = mockk()
     private val eventPublisher: ApplicationEventPublisher = mockk(relaxed = true)
 
@@ -64,6 +62,7 @@ class RoomServiceTest {
         roomInfoMapper = roomInfoMapper,
         memberMapper = memberMapper,
         roomSearchMapper = roomSearchMapper,
+        roomReadyMapper = roomReadyMapper,
         inviteCodeGenerator = inviteCodeGenerator,
         eventPublisher = eventPublisher
     )


### PR DESCRIPTION
## 🔍 개요
<!--
  무엇을 변경했나요?
  왜 변경했나요? (이유/동기/관련 테켓)
-->
티밍룸의 준비 상태를 조회하는 API를 구현했습니다.
또한, 기존 방 조회 API에서 티밍룸의 준비 상태를 같이 반환하도록 수정했습니다.

## 🔗 관련 이슈
<!--
  이슈 번호 및 링크
-->
#170
