### PR TITLE
fix: 팀플 성공인 방은 `everyMemberEntered`가 항상 true를 반환하도록 수정

### DIFF
--- a/src/main/kotlin/goodspace/teaming/chat/domain/mapper/RoomReadyMapper.kt
+++ b/src/main/kotlin/goodspace/teaming/chat/domain/mapper/RoomReadyMapper.kt
@@ -8,7 +8,7 @@ import org.springframework.stereotype.Component
 class RoomReadyMapper {
     fun map(room: Room): RoomReadyResponseDto {
         return RoomReadyResponseDto(
-            everyMemberEntered = room.everyMemberEntered()
+            everyMemberEntered = room.everyMemberEnteredOrSuccess()
         )
     }
 }

--- a/src/main/kotlin/goodspace/teaming/global/entity/room/Room.kt
+++ b/src/main/kotlin/goodspace/teaming/global/entity/room/Room.kt
@@ -57,8 +57,7 @@ class Room(
     val currentMemberCount
         get() = userRooms.size
 
-    fun everyMemberEntered(): Boolean {
-        // 팀플 성공인 방은 항상 true 반환
+    fun everyMemberEnteredOrSuccess(): Boolean {
         return memberCount == currentMemberCount || success
     }
 

--- a/src/test/kotlin/goodspace/teaming/chat/domain/mapper/RoomReadyMapperTest.kt
+++ b/src/test/kotlin/goodspace/teaming/chat/domain/mapper/RoomReadyMapperTest.kt
@@ -16,7 +16,7 @@ class RoomReadyMapperTest {
         fun `모든 인원이 참여했다면 true를 반환한다`() {
             // given
             val room = mockk<Room>()
-            every { room.everyMemberEntered() } returns true
+            every { room.everyMemberEnteredOrSuccess() } returns true
 
             // when
             val result = roomReadyMapper.map(room)
@@ -29,7 +29,7 @@ class RoomReadyMapperTest {
         fun `모든 인원이 참여하지 않았다면 false를 반환한다`() {
             // given
             val room = mockk<Room>()
-            every { room.everyMemberEntered() } returns false
+            every { room.everyMemberEnteredOrSuccess() } returns false
 
             // when
             val result = roomReadyMapper.map(room)


### PR DESCRIPTION
## 🔍 개요
<!--
  무엇을 변경했나요?
  왜 변경했나요? (이유/동기/관련 테켓)
-->
모든 멤버가 들어있는지에 대한 검증을, 팀플 성공이 있는 방에는 제외하도록 수정했습니다.

## 🔗 관련 이슈
<!--
  이슈 번호 및 링크
-->
#170 