### PR TITLE
chore: 모든 멤버가 참여하지 않았을 때 과제를 생성하지 못하도록 제한

### DIFF
--- a/src/main/kotlin/goodspace/teaming/assignment/service/AssignmentServiceImpl.kt
+++ b/src/main/kotlin/goodspace/teaming/assignment/service/AssignmentServiceImpl.kt
@@ -45,6 +45,7 @@ class AssignmentServiceImpl(
         val room = userRoom.room
 
         assertPayment(userRoom)
+        assertEveryMemberEntered(userRoom.room)
         assertLeader(userRoom)
 
         val assignment = assignmentMapper.map(room, requestDto)
@@ -146,6 +147,10 @@ class AssignmentServiceImpl(
 
     private fun assertLeader(userRoom: UserRoom) {
         check(userRoom.roomRole == RoomRole.LEADER) { NOT_LEADER }
+    }
+
+    private fun assertEveryMemberEntered(room: Room) {
+        check(room.everyMemberEnteredOrSuccess()) { EVERY_MEMBER_NOT_ENTERED }
     }
 
     private fun assertSubmitter(assignment: Assignment, submitter: User) {

--- a/src/main/kotlin/goodspace/teaming/global/exception/ErrorMessages.kt
+++ b/src/main/kotlin/goodspace/teaming/global/exception/ErrorMessages.kt
@@ -18,6 +18,7 @@ const val ROOM_INACCESSIBLE = "해당 티밍룸에 접근할 수 없습니다."
 const val WRONG_INVITE_CODE = "부적절한 초대 코드입니다."
 const val CANNOT_LEAVE_BEFORE_SUCCESS = "팀플에 성공하기 전까진 나갈 수 없습니다."
 const val ILLEGAL_ROOM_TITLE = "부적절한 티밍룸 제목입니다."
+const val EVERY_MEMBER_NOT_ENTERED = "아직 모든 인원이 참여하지 않았습니다."
 
 // Assignment
 const val ASSIGNMENT_NOT_FOUND = "과제를 찾을 수 없습니다."


### PR DESCRIPTION
## 🔍 개요
<!--
  무엇을 변경했나요?
  왜 변경했나요? (이유/동기/관련 테켓)
-->
모든 멤버가 입장하지 않았을 때 과제를 생성하지 못하도록 제한합니다.
모든 멤버가 입장한 후에 본격적인 기능을 사용할 수 있도록 제한하기 위함입니다.

## 🔗 관련 이슈
<!--
  이슈 번호 및 링크
-->
#166 

